### PR TITLE
Add config for MarkdownLint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,15 @@
 {
-    "editor.rulers": [80]
+    "editor.rulers": [80],
+    "markdownlint.config": {
+        "MD001": false,
+        "MD002": false,
+        "MD007": false,
+        "MD013": false,
+        "MD014": false,
+        "MD026": false,
+        "MD033": false,
+        "MD038": false,
+        "MD041": false,
+        "MD046": false
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,12 +4,16 @@
         "MD001": false,
         "MD002": false,
         "MD007": false,
-        "MD013": false,
+        "MD013": {
+            "headings": false,
+            "tables": false,
+            "code_blocks": false
+        },
         "MD014": false,
         "MD026": false,
-        "MD033": false,
-        "MD038": false,
-        "MD041": false,
-        "MD046": false
+        "MD033": {
+            "allowed_elements": ["img", "span", "sup"]
+        },
+        "MD041": false
     }
 }


### PR DESCRIPTION
Deactivate some rules for the VSCode extension `davidanson.vscode-markdownlint` in order to avoid unwanted warnings.