### PR TITLE
Fix Markdownlint warnings

### DIFF
--- a/FRENCH/src/ch00-00-introduction.md
+++ b/FRENCH/src/ch00-00-introduction.md
@@ -443,6 +443,7 @@ il ne compile pas ! Assurez-vous d'avoir lu le texte autour pour savoir si
 l'exemple que vous tentez de compiler doit échouer. Ferris va aussi vous aider
 à identifier du code qui ne devrait pas fonctionner :
 
+<!-- markdownlint-disable -->
 <!--
 | Ferris                                                                 | Meaning                                          |
 |------------------------------------------------------------------------|--------------------------------------------------|
@@ -451,6 +452,7 @@ l'exemple que vous tentez de compiler doit échouer. Ferris va aussi vous aider
 | <img src="img/ferris/unsafe.svg" class="ferris-explain"/>              | This code block contains unsafe code.            |
 | <img src="img/ferris/not_desired_behavior.svg" class="ferris-explain"/>| This code does not produce the desired behavior. |
 -->
+<!-- markdownlint-restore -->
 
 | Ferris                                                                 | Signification                                    |
 |------------------------------------------------------------------------|--------------------------------------------------|

--- a/FRENCH/src/ch01-01-installation.md
+++ b/FRENCH/src/ch01-01-installation.md
@@ -178,7 +178,8 @@ les outils de compilation est d'installer
 
 [install]: https://www.rust-lang.org/tools/install
 <!--
-[visualstudio]: https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2019
+[visualstudio]:
+https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2019
 FR translation: the website redirects to French version, we lose the "id" link.
 Fix is directly below:
 -->

--- a/FRENCH/src/ch01-01-installation.md
+++ b/FRENCH/src/ch01-01-installation.md
@@ -176,13 +176,16 @@ pour Visual Studio 2013 ou plus récent. La méthode la plus facile pour obtenir
 les outils de compilation est d'installer
 [Build Tools pour Visual Studio 2019][visualstudio].
 
-[install]: https://www.rust-lang.org/tools/install
+<!-- markdownlint-disable -->
 <!--
-[visualstudio]:
-https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2019
+[install]: https://www.rust-lang.org/tools/install
+[visualstudio]: https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2019
 FR translation: the website redirects to French version, we lose the "id" link.
 Fix is directly below:
 -->
+<!-- markdownlint-restore -->
+
+[install]: https://www.rust-lang.org/tools/install
 [visualstudio]: https://www.visualstudio.com/fr/downloads/#build-tools-for-visual-studio-2019
 
 <!--

--- a/FRENCH/src/ch01-02-hello-world.md
+++ b/FRENCH/src/ch01-02-hello-world.md
@@ -81,7 +81,6 @@ For Windows CMD, enter this:
 
 Avec CMD sous Windows, écrivez ceci :
 
-
 ```cmd
 > mkdir "%USERPROFILE%\projects"
 > cd /d "%USERPROFILE%\projects"

--- a/FRENCH/src/ch02-00-guessing-game-tutorial.md
+++ b/FRENCH/src/ch02-00-guessing-game-tutorial.md
@@ -1529,6 +1529,7 @@ However, the code in Listing 2-4 won’t compile yet. Let’s try it:
 Cependant, notre code dans l'encart 2-4 ne compile pas encore. Essayons de le
 faire :
 
+<!-- markdownlint-disable -->
 <!--
 ```text
 $ cargo build
@@ -1546,6 +1547,7 @@ error: aborting due to previous error
 Could not compile `guessing_game`.
 ```
 -->
+<!-- markdownlint-restore -->
 
 ```text
 $ cargo build
@@ -1769,7 +1771,8 @@ L'utilisation de `parse` peut facilement mener à une erreur. Si par exemple,
 le texte contient `A👍%`, il ne sera pas possible de le convertir en nombre.
 Comme elle peut échouer, la méthode `parse` retourne un type `Result`, comme
 celui que la méthode `read_line` retourne (comme nous l'avons vu plus tôt dans
-[“Gérer les erreurs potentielles avec le type `Result`”](#gérer-les-erreurs-potentielles-avec-le-type-result)<!-- ignore-->).
+[“Gérer les erreurs potentielles avec le type
+`Result`”](#gérer-les-erreurs-potentielles-avec-le-type-result)<!-- ignore-->).
 Nous allons gérer ce `Result` de la même manière, avec à nouveau la méthode
 `expect`. Si `parse` retourne une variante `Err` de `Result` car elle ne peut
 pas créer un nombre à partir de la chaîne de caractères, l'appel à
@@ -1922,11 +1925,12 @@ user can take advantage of that in order to quit, as shown here:
 L'utilisateur pourrait quand même interrompre le programme en utilisant le
 raccourci clavier <span class="keystroke">ctrl-c</span>.
 Mais il y a une autre façon d'échapper à ce monstre insatiable, comme nous
-l'avons abordé dans la partie
-[“Comparer le nombre saisi au nombre secret”](#comparer-le-nombre-saisi-au-nombre-secret)<!-- ignore --> :
-si l'utilisateur saisit quelque chose qui n'est pas un nombre, le programme va
+l'avons abordé dans la partie [“Comparer le nombre saisi au nombre
+secret”](#comparer-le-nombre-saisi-au-nombre-secret)<!-- ignore --> : si
+l'utilisateur saisit quelque chose qui n'est pas un nombre, le programme va
 planter. L'utilisateur peut procéder ainsi pour le quitter, comme ci-dessous :
 
+<!-- markdownlint-disable -->
 <!--
 ```text
 $ cargo run
@@ -1954,6 +1958,7 @@ note: Run with `RUST_BACKTRACE=1` for a backtrace.
 error: Process didn't exit successfully: `target/debug/guess` (exit code: 101)
 ```
 -->
+<!-- markdownlint-restore -->
 
 ```text
 $ cargo run

--- a/FRENCH/src/ch03-01-variables-and-mutability.md
+++ b/FRENCH/src/ch03-01-variables-and-mutability.md
@@ -375,8 +375,8 @@ can shadow a variable by using the same variable’s name and repeating the use
 of the `let` keyword as follows:
 -->
 
-Comme nous l'avons vu dans la section
-[“Comparer le nombre saisi au nombre secret”][comparing-the-guess-to-the-secret-number]<!-- ignore -->
+Comme nous l'avons vu dans la section [“Comparer le nombre saisi au nombre
+secret”][comparing-the-guess-to-the-secret-number]<!-- ignore -->
 du jeu de devinettes au chapitre 2, on peut déclarer une nouvelle variable
 avec le même nom qu'une variable précédente, et la nouvelle variable
 masquera la première. Les Rustacés disent que la première variable est *masquée*

--- a/FRENCH/src/ch03-02-data-types.md
+++ b/FRENCH/src/ch03-02-data-types.md
@@ -31,7 +31,8 @@ compilation. Le compilateur peut souvent déduire quel type utiliser en se basan
 sur la valeur et sur la façon dont elle est utilisée. Dans les cas où plusieurs
 types sont envisageables, comme lorsque nous avons converti une chaîne de
 caractères en un type numérique en utilisant `parse` dans la section
-[“Comparer le nombre saisi au nombre secret”][comparing-the-guess-to-the-secret-number]<!-- ignore -->
+[“Comparer le nombre saisi au nombre
+secret”][comparing-the-guess-to-the-secret-number]<!-- ignore -->
 du chapitre 2, nous devons ajouter une annotation de type, comme ceci :
 
 <!--
@@ -162,7 +163,8 @@ with it (signed) or whether it will only ever be positive and can therefore be
 represented without a sign (unsigned). It’s like writing numbers on paper: when
 the sign matters, a number is shown with a plus sign or a minus sign; however,
 when it’s safe to assume the number is positive, it’s shown with no sign.
-Signed numbers are stored using [two’s complement](https://en.wikipedia.org/wiki/Two%27s_complement) representation.
+Signed numbers are stored using [two’s
+complement](https://en.wikipedia.org/wiki/Two%27s_complement) representation.
 -->
 
 Chaque variante peut-être signée ou non signée et possède une taille explicite.

--- a/FRENCH/src/ch03-02-data-types.md
+++ b/FRENCH/src/ch03-02-data-types.md
@@ -155,6 +155,7 @@ valeur entière.
 | 128 bits| `i128`  | `u128`    |
 | archi   | `isize` | `usize`   |
 
+<!-- markdownlint-disable -->
 <!--
 Each variant can be either signed or unsigned and has an explicit size.
 *Signed* and *unsigned* refer to whether it’s possible for the number to be
@@ -163,9 +164,9 @@ with it (signed) or whether it will only ever be positive and can therefore be
 represented without a sign (unsigned). It’s like writing numbers on paper: when
 the sign matters, a number is shown with a plus sign or a minus sign; however,
 when it’s safe to assume the number is positive, it’s shown with no sign.
-Signed numbers are stored using [two’s
-complement](https://en.wikipedia.org/wiki/Two%27s_complement) representation.
+Signed numbers are stored using [two’s complement](https://en.wikipedia.org/wiki/Two%27s_complement) representation.
 -->
+<!-- markdownlint-restore -->
 
 Chaque variante peut-être signée ou non signée et possède une taille explicite.
 *Signé* et *non signé* veut dire respectivement que le nombre peut prendre ou

--- a/FRENCH/src/ch03-03-how-functions-work.md
+++ b/FRENCH/src/ch03-03-how-functions-work.md
@@ -379,10 +379,11 @@ fn main() {
 }
 ```
 
+<!-- markdownlint-disable -->
 <!--
-<span class="caption">Listing 3-1: A `main` function declaration containing one
-statement</span>
+<span class="caption">Listing 3-1: A `main` function declaration containing one statement</span>
 -->
+<!-- markdownlint-restore -->
 
 <span class="caption">Encart 3-1 : une fonction `main` qui contient une
 instruction</span>

--- a/FRENCH/src/ch03-03-how-functions-work.md
+++ b/FRENCH/src/ch03-03-how-functions-work.md
@@ -380,7 +380,8 @@ fn main() {
 ```
 
 <!--
-<span class="caption">Listing 3-1: A `main` function declaration containing one statement</span>
+<span class="caption">Listing 3-1: A `main` function declaration containing one
+statement</span>
 -->
 
 <span class="caption">Encart 3-1 : une fonction `main` qui contient une

--- a/FRENCH/src/ch03-05-control-flow.md
+++ b/FRENCH/src/ch03-05-control-flow.md
@@ -742,10 +742,9 @@ guessing the correct number.
 Heureusement, Rust fournit un autre moyen, plus fiable, de sortir d'une boucle.
 Vous pouvez ajouter le mot-clé `break` à l'intérieur de la boucle pour demander
 au programme d'arrêter la boucle. Souvenez-vous que nous avions fait ceci dans
-le jeu de devinettes, dans la section
-[“Arrêter le programme après avoir gagné”][quitting-after-a-correct-guess]<!-- ignore -->
-du chapitre 2 afin de quitter le programme quand l'utilisateur gagne le jeu en
-devinant le bon nombre.
+le jeu de devinettes, dans la section [“Arrêter le programme après avoir
+gagné”][quitting-after-a-correct-guess]<!-- ignore --> du chapitre 2 afin de
+quitter le programme quand l'utilisateur gagne le jeu en devinant le bon nombre.
 
 <!--
 #### Returning Values from Loops

--- a/FRENCH/src/ch04-01-what-is-ownership.md
+++ b/FRENCH/src/ch04-01-what-is-ownership.md
@@ -401,8 +401,8 @@ fonction spécifique dans l'espace de nom du type `String` plutôt que d'utilise
 un nom comme `string_from`. Nous verrons cette syntaxe plus en détail dans la
 section [“Syntaxe de méthode”][method-syntax]<!-- ignore --> du chapitre 5 et
 lorsque nous aborderons les espaces de noms dans la section
-[“Les chemins pour désigner un élément dans l'arborescence de module”][paths-module-tree]<!-- ignore -->
-du chapitre 7.
+[“Les chemins pour désigner un élément dans l'arborescence de
+module”][paths-module-tree]<!-- ignore --> du chapitre 7.
 
 <!--
 This kind of string *can* be mutated:
@@ -663,7 +663,13 @@ un pointeur vers la mémoire qui contient le contenu de la chaîne de caractère
 une taille, et une capacité. Ce groupe de données est stocké sur la pile. À
 droite, nous avons la mémoire sur le tas qui contient les données.
 
-<img alt="String in memory" src="img/trpl04-01.svg" class="center" style="width: 50%;" />
+<!--
+<img alt="String in memory" src="img/trpl04-01.svg" class="center"
+style="width: 50%;" />
+-->
+
+<img alt="Une string en mémoire" src="img/trpl04-01.svg" class="center"
+style="width: 50%;" />
 
 <!--
 <span class="caption">Figure 4-1: Representation in memory of a `String`
@@ -700,7 +706,13 @@ stockés sur la pile. Nous ne copions pas les données stockées sur le tas
 auxquelles le pointeur se réfère. Autrement dit, la représentation des données
 dans la mémoire ressemble à l'illustration 4-2.
 
-<img alt="s1 and s2 pointing to the same value" src="img/trpl04-02.svg" class="center" style="width: 50%;" />
+<!--
+<img alt="s1 and s2 pointing to the same value" src="img/trpl04-02.svg"
+class="center" style="width: 50%;" />
+-->
+
+<img alt="s1 et s2 qui pointent vers la même valeur" src="img/trpl04-02.svg"
+class="center" style="width: 50%;" />
 
 <!--
 <span class="caption">Figure 4-2: Representation in memory of the variable `s2`
@@ -723,7 +735,13 @@ mémoire si Rust avait aussi copié les données sur le tas. Si Rust faisait cec
 l'opération `s2 = s1` pourrait potentiellement être très coûteuse en termes de
 performances d'exécution si les données sur le tas étaient volumineuses.
 
-<img alt="s1 and s2 to two places" src="img/trpl04-03.svg" class="center" style="width: 50%;" />
+<!--
+<img alt="s1 and s2 to two places" src="img/trpl04-03.svg" class="center"
+style="width: 50%;" />
+-->
+
+<img alt="s1 et s2 à deux endroits" src="img/trpl04-03.svg" class="center"
+style="width: 50%;" />
 
 <!--
 <span class="caption">Figure 4-3: Another possibility for what `s2 = s1` might
@@ -815,7 +833,13 @@ lieu d'appeler cela une copie superficielle, on appelle cela un *déplacement*.
 Ici, nous pourrions dire que `s1` a été *déplacé* dans `s2`. Donc ce qui se
 passe réellement est décrit par l'illustration 4-4.
 
-<img alt="s1 moved to s2" src="img/trpl04-04.svg" class="center" style="width: 50%;" />
+<!--
+<img alt="s1 moved to s2" src="img/trpl04-04.svg" class="center"
+style="width: 50%;" />
+-->
+
+<img alt="s1 déplacé dans s2" src="img/trpl04-04.svg" class="center"
+style="width: 50%;" />
 
 <!--
 <span class="caption">Figure 4-4: Representation in memory after `s1` has been
@@ -858,7 +882,7 @@ programming languages, you’ve probably seen them before.
 -->
 
 Si nous *voulons* faire une copie profonde des données sur le tas d'une
-`String`, et pas seulement des données sur la pile, nous pouvons utiliser une 
+`String`, et pas seulement des données sur la pile, nous pouvons utiliser une
 méthode commune qui s'appelle `clone`. Nous aborderons la syntaxe des méthodes
 au chapitre 5, mais comme les méthodes sont des outils courants dans de
 nombreux langages, vous les avez probablement utilisées auparavant.
@@ -1048,7 +1072,7 @@ fn makes_copy(some_integer: i32) { // some_integer comes into scope
 -->
 
 ```rust
-fn main() { 
+fn main() {
     let s = String::from("hello");  // s rentre dans la portée.
 
     prendre_possession(s);  // La valeur de s est déplacée dans la fonction…
@@ -1281,7 +1305,8 @@ c'est ce qu'on appelle les *références*.
 [data-types]: ch03-02-data-types.html#data-types
 [derivable-traits]: appendix-03-derivable-traits.html
 [method-syntax]: ch05-03-method-syntax.html#method-syntax
-[paths-module-tree]: ch07-03-paths-for-referring-to-an-item-in-the-module-tree.html
+[paths-module-tree]:
+ch07-03-paths-for-referring-to-an-item-in-the-module-tree.html
 -->
 
 [data-types]: ch03-02-data-types.html

--- a/FRENCH/src/ch04-01-what-is-ownership.md
+++ b/FRENCH/src/ch04-01-what-is-ownership.md
@@ -663,10 +663,11 @@ un pointeur vers la mémoire qui contient le contenu de la chaîne de caractère
 une taille, et une capacité. Ce groupe de données est stocké sur la pile. À
 droite, nous avons la mémoire sur le tas qui contient les données.
 
+<!-- markdownlint-disable -->
 <!--
-<img alt="String in memory" src="img/trpl04-01.svg" class="center"
-style="width: 50%;" />
+<img alt="String in memory" src="img/trpl04-01.svg" class="center" style="width: 50%;" />
 -->
+<!-- markdownlint-restore -->
 
 <img alt="Une string en mémoire" src="img/trpl04-01.svg" class="center"
 style="width: 50%;" />
@@ -706,10 +707,11 @@ stockés sur la pile. Nous ne copions pas les données stockées sur le tas
 auxquelles le pointeur se réfère. Autrement dit, la représentation des données
 dans la mémoire ressemble à l'illustration 4-2.
 
+<!-- markdownlint-disable -->
 <!--
-<img alt="s1 and s2 pointing to the same value" src="img/trpl04-02.svg"
-class="center" style="width: 50%;" />
+<img alt="s1 and s2 pointing to the same value" src="img/trpl04-02.svg" class="center" style="width: 50%;" />
 -->
+<!-- markdownlint-restore -->
 
 <img alt="s1 et s2 qui pointent vers la même valeur" src="img/trpl04-02.svg"
 class="center" style="width: 50%;" />
@@ -735,10 +737,11 @@ mémoire si Rust avait aussi copié les données sur le tas. Si Rust faisait cec
 l'opération `s2 = s1` pourrait potentiellement être très coûteuse en termes de
 performances d'exécution si les données sur le tas étaient volumineuses.
 
+<!-- markdownlint-disable -->
 <!--
-<img alt="s1 and s2 to two places" src="img/trpl04-03.svg" class="center"
-style="width: 50%;" />
+<img alt="s1 and s2 to two places" src="img/trpl04-03.svg" class="center" style="width: 50%;" />
 -->
+<!-- markdownlint-restore -->
 
 <img alt="s1 et s2 à deux endroits" src="img/trpl04-03.svg" class="center"
 style="width: 50%;" />
@@ -833,10 +836,11 @@ lieu d'appeler cela une copie superficielle, on appelle cela un *déplacement*.
 Ici, nous pourrions dire que `s1` a été *déplacé* dans `s2`. Donc ce qui se
 passe réellement est décrit par l'illustration 4-4.
 
+<!-- markdownlint-disable -->
 <!--
-<img alt="s1 moved to s2" src="img/trpl04-04.svg" class="center"
-style="width: 50%;" />
+<img alt="s1 moved to s2" src="img/trpl04-04.svg" class="center" style="width: 50%;" />
 -->
+<!-- markdownlint-restore -->
 
 <img alt="s1 déplacé dans s2" src="img/trpl04-04.svg" class="center"
 style="width: 50%;" />
@@ -1301,13 +1305,14 @@ Mais c'est trop laborieux et beaucoup de travail pour un principe qui devrait
 être banal. Heureusement pour nous, Rust a une fonctionnalité pour ce principe,
 c'est ce qu'on appelle les *références*.
 
+<!-- markdownlint-disable -->
 <!--
 [data-types]: ch03-02-data-types.html#data-types
 [derivable-traits]: appendix-03-derivable-traits.html
 [method-syntax]: ch05-03-method-syntax.html#method-syntax
-[paths-module-tree]:
-ch07-03-paths-for-referring-to-an-item-in-the-module-tree.html
+[paths-module-tree]: ch07-03-paths-for-referring-to-an-item-in-the-module-tree.html
 -->
+<!-- markdownlint-restore -->
 
 [data-types]: ch03-02-data-types.html
 [derivable-traits]: appendix-03-derivable-traits.html


### PR DESCRIPTION
I have fixed the Markdownlint warnings in the files that are already translated.

Note that when it wasn't possible to fix the warning without compromising the text structure (notably code blocks and tables in comments), I had to surround it with `<!-- markdownlint-disable -->` and `<!-- markdownlint-restore -->`.