### PR TITLE
Proofread ch06-01

### DIFF
--- a/FRENCH/src/ch06-01-defining-an-enum.md
+++ b/FRENCH/src/ch06-01-defining-an-enum.md
@@ -33,10 +33,10 @@ situations that apply to any kind of IP address.
 N'importe quelle adresse IP peut être soit une adresse en version quatre, soit
 en version six, mais pas les deux en même temps. Cette propriété des adresses IP
 est appropriée à la structure de données d'énumérations, car les valeurs de
-l'énumération peuvent être uniquement qu'une des variantes. Les adresses en
-version quatre et six sont toujours fondamentalement des adresses IP, donc elles
-doivent être traitées comme étant du même type lorsque le code travaille avec
-des situations qui s'appliquent à n'importe quel type d'adresses IP.
+l'énumération ne peuvent être qu'une de ses variantes. Les adresses en version
+quatre et six sont toujours fondamentalement des adresses IP, donc elles doivent
+être traitées comme étant du même type lorsque le code travaille avec des
+situations qui s'appliquent à n'importe quelle sorte d'adresse IP.
 
 <!--
 We can express this concept in code by defining an `IpAddrKind` enumeration and
@@ -45,7 +45,7 @@ variants of the enum:
 -->
 
 Nous pouvons exprimer ce concept dans le code en définissant une énumération
-`TypeAdresseIp` et en listant les différents types possibles d'adresses IP
+`SorteAdresseIp` et en listant les différentes sortes possibles d'adresses IP
 qu'elle peut avoir, `V4` et `V6`. Ce sont les variantes de l'énumération :
 
 <!--
@@ -58,7 +58,7 @@ enum IpAddrKind {
 -->
 
 ```rust
-enum TypeAdresseIp {
+enum SorteAdresseIp {
     V4,
     V6,
 }
@@ -68,7 +68,7 @@ enum TypeAdresseIp {
 `IpAddrKind` is now a custom data type that we can use elsewhere in our code.
 -->
 
-`TypeAdresseIp` est maintenant un type de données personnalisé que nous pouvons
+`SorteAdresseIp` est maintenant un type de données personnalisé que nous pouvons
 utiliser n'importe où dans notre code.
 
 <!--
@@ -82,7 +82,7 @@ We can create instances of each of the two variants of `IpAddrKind` like this:
 -->
 
 Nous pouvons créer des instances de chacune des deux variantes de
-`TypeAdresseIp` de cette manière :
+`SorteAdresseIp` de cette manière :
 
 <!--
 ```rust
@@ -97,13 +97,13 @@ let six = IpAddrKind::V6;
 -->
 
 ```rust
-# enum TypeAdresseIp {
+# enum SorteAdresseIp {
 #     V4,
 #     V6,
 # }
 #
-let quatre = TypeAdresseIp::V4;
-let six = TypeAdresseIp::V6;
+let quatre = SorteAdresseIp::V4;
+let six = SorteAdresseIp::V6;
 ```
 
 <!--
@@ -115,11 +115,11 @@ both values `IpAddrKind::V4` and `IpAddrKind::V6` are of the same type:
 -->
 
 Remarquez que les variantes de l'énumération sont dans un espace de nom qui se
-situe avant son nom, et nous utilisons un double deux-points pour les séparer
-tous les deux. C'est utile car maintenant les deux valeurs `TypeAdresseIp::V4`
-et `TypeAdresseIp::V6` sont du même type : `TypeAdresseIp`. Ensuite, nous
-pouvons, par exemple, définir une fonction qui accepte n'importe quel
-`TypeAdresseIp` :
+situe avant leur nom, et nous utilisons un double deux-points pour les séparer
+tous les deux. C'est utile car maintenant les deux valeurs `SorteAdresseIp::V4`
+et `SorteAdresseIp::V6` sont du même type : `SorteAdresseIp`. Ensuite, nous
+pouvons, par exemple, définir une fonction qui accepte n'importe quelle
+`SorteAdresseIp` :
 
 <!--
 ```rust
@@ -133,12 +133,12 @@ fn route(ip_kind: IpAddrKind) { }
 -->
 
 ```rust
-# enum TypeAdresseIp {
+# enum SorteAdresseIp {
 #     V4,
 #     V6,
 # }
 #
-fn route(type_ip: TypeAdresseIp) { }
+fn router(sorte_ip: SorteAdresseIp) { }
 ```
 
 <!--
@@ -162,15 +162,15 @@ route(IpAddrKind::V6);
 -->
 
 ```rust
-# enum TypeAdresseIp {
+# enum SorteAdresseIp {
 #     V4,
 #     V6,
 # }
 #
-# fn route(type_ip: TypeAdresseIp) { }
+# fn router(sorte_ip: SorteAdresseIp) { }
 #
-route(TypeAdresseIp::V4);
-route(TypeAdresseIp::V6);
+router(SorteAdresseIp::V4);
+router(SorteAdresseIp::V6);
 ```
 
 <!--
@@ -182,9 +182,9 @@ Chapter 5, you might tackle this problem as shown in Listing 6-1.
 
 L'utilisation des énumérations a encore plus d'avantages. En étudiant un peu
 plus notre type d'adresse IP, nous constatons que pour le moment, nous ne
-pouvons pas stocker *la donnée* de l'adresse IP; nous savons uniquement de quel
-type elle est. Avec ce que vous avez appris au chapitre 5, vous pouvez résoudre
-ce problème comme dans l'encart 6-1.
+pouvons pas stocker *la donnée* de l'adresse IP ; nous savons seulement de
+quelle sorte elle est. Avec ce que vous avez appris au chapitre 5, vous pouvez
+résoudre ce problème comme dans l'encart 6-1.
 
 <!--
 ```rust
@@ -211,23 +211,23 @@ let loopback = IpAddr {
 -->
 
 ```rust
-enum TypeAdresseIp {
+enum SorteAdresseIp {
     V4,
     V6,
 }
 
 struct AdresseIp {
-    type: TypeAdresseIp,
+    sorte: SorteAdresseIp,
     adresse: String,
 }
 
 let local = AdresseIp {
-    type: TypeAdresseIp::V4,
+    sorte: SorteAdresseIp::V4,
     adresse: String::from("127.0.0.1"),
 };
 
-let bouclage = AdresseIp {
-    type: TypeAdresseIp::V6,
+let rebouclage = AdresseIp {
+    sorte: SorteAdresseIp::V6,
     adresse: String::from("::1"),
 };
 ```
@@ -238,7 +238,7 @@ an IP address using a `struct`</span>
 -->
 
 <span class="caption">Encart 6-1 : Stockage de la donnée et de la variante de
-`TypeAdresseIp` d'une adresse IP en utilisant une `struct`</span>
+`SorteAdresseIp` d'une adresse IP en utilisant une `struct`</span>
 
 <!--
 Here, we’ve defined a struct `IpAddr` that has two fields: a `kind` field that
@@ -252,14 +252,14 @@ now the variant is associated with the value.
 -->
 
 Ainsi, nous avons défini une structure `AdresseIp` qui a deux champs : un champ
-`type` qui est du type `TypeAdresseIp` (l'énumération que nous avons définie
+`sorte` qui est du type `SorteAdresseIp` (l'énumération que nous avons définie
 précédemment) et un champ `adresse` qui est du type `String`. Nous avons deux
 instances de cette structure. La première, `local`, a la valeur
-`TypeAdresseIp::V4` pour son `type`, associé à la donnée d'adresse qui est
-`127.0.0.1`. La seconde instance, `bouclage`, a pour sa valeur `type` l'autre
-variante de `TypeAdresseIp`, `V6`, et a l'adresse`::1` qui lui est associée.
-Nous avons utilisé une structure pour relier ensemble le `type` avec `adresse`,
-donc maintenant la variante est liée à la valeur.
+`SorteAdresseIp::V4` pour son champ `sorte`, associé à la donnée d'adresse qui
+est `127.0.0.1`. La seconde instance, `rebouclage`, a comme valeur de champ
+`sorte` l'autre variante de `SorteAdresseIp`, `V6`, et a l'adresse`::1` qui lui
+est associée. Nous avons utilisé une structure pour relier ensemble la `sorte`
+et l'`adresse`, donc maintenant la variante est liée à la valeur.
 
 <!--
 We can represent the same concept in a more concise way using just an enum,
@@ -271,7 +271,7 @@ variants will have associated `String` values:
 Nous pouvons appliquer le même principe de manière plus concise en utilisant
 uniquement une énumération, plutôt que d'utiliser une énumération dans une
 structure, en insérant directement la donnée dans chaque variante de
-l'énumération. Cette nouvelle définition de l'énumération de `AdresseIp` indique
+l'énumération. Cette nouvelle définition de l'énumération `AdresseIp` indique
 que chacune des variantes `V4` et `V6` auront des valeurs associées de type
 `String` :
 
@@ -296,7 +296,7 @@ enum AdresseIp {
 
 let local = AdresseIp::V4(String::from("127.0.0.1"));
 
-let bouclage = AdresseIp::V6(String::from("::1"));
+let rebouclage = AdresseIp::V6(String::from("::1"));
 ```
 
 <!--
@@ -316,14 +316,14 @@ still express `V6` addresses as one `String` value, we wouldn’t be able to wit
 a struct. Enums handle this case with ease:
 -->
 
-Il y a un autre avantage à utiliser les énumérations plutôt qu'une structure : 
+Il y a un autre avantage à utiliser une énumération plutôt qu'une structure :
 chaque variante peut stocker des types différents, et aussi avoir une quantité
-différente de données associées. Les adresses IP de type version quatre vont
-toujours avoir quatre composantes numériques qui auront une valeur entre 0
-et 255. Si nous voulions stocker les adresses `V4` avec quatre valeurs de type
-`u8` mais continuer à stocker les adresses `V6` dans une `String`, nous ne
-pourrions pas le faire avec une structure. Les énumérations permettent de faire
-cela facilement :
+différente de données associées. Les adresses IP version quatre vont toujours
+avoir quatre composantes numériques qui auront une valeur entre 0 et 255. Si
+nous voulions stocker les adresses `V4` avec quatre valeurs de type `u8` mais
+continuer à stocker les adresses `V6` dans une `String`, nous ne pourrions pas
+le faire avec une structure. Les énumérations permettent de faire cela
+facilement :
 
 <!--
 ```rust
@@ -346,7 +346,7 @@ enum AdresseIp {
 
 let local = AdresseIp::V4(127, 0, 0, 1);
 
-let bouclage = AdresseIp::V6(String::from("::1"));
+let rebouclage = AdresseIp::V6(String::from("::1"));
 ```
 
 <!--
@@ -362,11 +362,11 @@ variant:
 
 Nous avons vu différentes manières de définir des structures de données pour
 enregistrer des adresses IP en version quatre et version six. Cependant, il
-s'avère que vouloir stocker les adresses IP et identifier de quel type elles
+s'avère que vouloir stocker des adresses IP et identifier de quelle sorte elles
 sont est si fréquent que [la bibliothèque standard a une définition que nous
 pouvons utiliser !][IpAddr]<!-- ignore --> Analysons comment la bibliothèque
 standard a défini `IpAddr` (l'équivalent de notre `AdresseIp`) : nous retrouvons
-la même énumération et les variantes que nous avons définies et utilisé, mais
+la même énumération et les variantes que nous avons définies et utilisées, mais
 stocke les données d'adresse dans des variantes dans deux structures
 différentes, qui sont définies chacune pour chaque variante :
 
@@ -416,7 +416,7 @@ what you might come up with.
 -->
 
 Ce code montre comment vous pouvez insérer n'importe quel type de données dans
-une variante d'énumération : des chaînes de caractères, des nombres, ou des
+une variante d'énumération : des chaînes de caractères, des nombres ou des
 structures, par exemple. Vous pouvez même y intégrer d'autres énumérations ! Par
 ailleurs, les types de la bibliothèque standard ne sont parfois pas plus
 compliqués que ce que vous pourriez inventer.
@@ -429,10 +429,10 @@ more about bringing types into scope in Chapter 7.
 -->
 
 Notez aussi que même si la bibliothèque standard embarque une définition de
-`IpAddr`, nous pouvons quand même créer et utiliser notre propre définition sans
-avoir de conflits car nous n'avons pas importé cette définition de la
-bibliothèque standard dans la portée. Nous verrons plus en détail comment
-importer les types dans la portée au chapitre 7.
+`IpAddr`, nous pouvons quand même créer et utiliser notre propre définition de
+ce type sans avoir de conflit de nom car nous n'avons pas importé cette
+définition de la bibliothèque standard dans la portée. Nous verrons plus en
+détail comment importer les types dans la portée au chapitre 7.
 
 <!--
 Let’s look at another example of an enum in Listing 6-2: this one has a wide
@@ -468,7 +468,8 @@ different amounts and types of values</span>
 -->
 
 <span class="caption">Encart 6-2 : Une énumération `Message` dont chaque
-variante stocke chacune différents types et quantités de valeurs</span>
+variante stocke des valeurs de différents types et en différentes
+quantités</span>
 
 <!--
 This enum has four variants with different types:
@@ -484,9 +485,9 @@ Cette énumération a quatre variantes avec des types différents :
 -->
 
 * `Quitter` n'a pas du tout de donnée associée.
-* `Déplacer` intègre une structure anonyme.
+* `Deplacer` intègre une structure anonyme.
 * `Ecrire` intègre une seule `String`.
-* `ChangeColor` intègre trois valeurs de type `i32`.
+* `ChangerCouleur` intègre trois valeurs de type `i32`.
 
 <!--
 Defining an enum with variants such as the ones in Listing 6-2 is similar to
@@ -497,7 +498,7 @@ variants hold:
 -->
 
 Définir une énumération avec des variantes comme celles dans l'encart 6-2
-ressemble à la définition de différents types de structures, sauf que
+ressemble à la définition de différentes sortes de structures, sauf que
 l'énumération n'utilise pas le mot-clé `struct` et que toutes les variantes sont
 regroupées ensemble sous le type `Message`. Les structures suivantes peuvent
 stocker les mêmes données que celles stockées par les variantes précédentes :
@@ -515,7 +516,7 @@ struct ChangeColorMessage(i32, i32, i32); // tuple struct
 -->
 
 ```rust
-struct MessageQuitter; // structure unitaire
+struct MessageQuitter; // une structure unité
 struct MessageDeplacer {
     x: i32,
     y: i32,
@@ -530,11 +531,11 @@ couldn’t as easily define a function to take any of these kinds of messages as
 we could with the `Message` enum defined in Listing 6-2, which is a single type.
 -->
 
-Mais si nous utilisons les différentes structures, qui ont chacune leur propre
+Mais si nous utilisions les différentes structures, qui ont chacune leur propre
 type, nous ne pourrions pas définir facilement une fonction qui prend en
-paramètre tous les types de messages, tel que nous pourrions le faire avec
-l'énumération `Message` que nous avons défini dans l'encart 6-2, qui est un seul
-type.
+paramètre toutes les sortes de messages, tel que nous pourrions le faire avec
+l'énumération `Message` que nous avons définie dans l'encart 6-2, qui est un
+seul type.
 
 <!--
 There is one more similarity between enums and structs: just as we’re able to
@@ -542,10 +543,10 @@ define methods on structs using `impl`, we’re also able to define methods on
 enums. Here’s a method named `call` that we could define on our `Message` enum:
 -->
 
-Il y a un autre point commun entre les énumérations et les structures : comme
-nous pouvons définir des méthodes sur les structures en utilisant `impl`, nous
-pouvons aussi définir des méthodes sur des énumérations. Voici une méthode
-appelée `call` que nous pouvons définir sur notre énumération `Message` :
+Il y a un autre point commun entre les énumérations et les structures : tout
+comme on peut définir des méthodes sur les structures en utilisant `impl`, on
+peut aussi définir des méthodes sur des énumérations. Voici une méthode appelée
+`appeler` que nous pouvons définir sur notre énumération `Message` :
 
 <!--
 ```rust
@@ -576,13 +577,13 @@ m.call();
 # }
 #
 impl Message {
-    fn call(&self) {
+    fn appeler(&self) {
         // le corps de la méthode sera défini ici
     }
 }
 
 let m = Message::Ecrire(String::from("hello"));
-m.call();
+m.appeler();
 ```
 
 <!--
@@ -595,8 +596,8 @@ body of the `call` method when `m.call()` runs.
 Le corps de la méthode va utiliser `self` pour obtenir la valeur sur laquelle
 nous avons utilisé la méthode. Dans cet exemple, nous avons créé une variable
 `m` qui a la valeur `Message::Ecrire(String::from("hello"))`, et cela sera ce
-que `self` aura pour valeur dans le corps de la méthode `call` quand nous
-lancerons `m.call()`.
+que `self` aura comme valeur dans le corps de la méthode `appeler` quand nous
+lancerons `m.appeler()`.
 
 <!--
 Let’s look at another enum in the standard library that is very common and
@@ -610,7 +611,7 @@ très utilisée et utile : `Option`.
 ### The `Option` Enum and Its Advantages Over Null Values
 -->
 
-### L'énumération `Option` et ses avantages par rapport à la valeur Null
+### L'énumération `Option` et ses avantages par rapport à la valeur null
 
 <!--
 In the previous section, we looked at how the `IpAddr` enum let us use Rust’s
@@ -628,12 +629,12 @@ Dans la section précédente, nous avons découvert comment l'énumération
 `AdresseIp` nous permet d'utiliser le système de types de Rust pour enregistrer
 dans nos programmes encore plus d'informations qu'uniquement la donnée. Cette
 section étudie le cas de `Option`, qui est une autre énumération définie dans la
-bibliothèque standard. Le type `Option` est utilisée dans de nombreux endroits
-car il décrit un scénario très courant durant lequel une valeur peut être
-quelque chose ou rien du tout. Exprimer ce concept avec le système de types
-implique que le compilateur doit pouvoir vérifier si vous avez géré tous les cas
-que vous pourriez avoir; cette fonctionnalité peut éviter des bogues qui sont
-très courants dans d'autres langages de programmation.
+bibliothèque standard. Le type `Option` est utilisé dans de nombreux endroits
+car il décrit un scénario très courant où une valeur peut être soit quelque
+chose, soit rien du tout. Exprimer ce concept avec le système de types implique
+que le compilateur peut vérifier si vous avez géré tous les cas que vous
+pourriez rencontrer ; cette fonctionnalité peut éviter des bogues qui sont très
+courants dans d'autres langages de programmation.
 
 <!--
 Programming language design is often thought of in terms of which features you
@@ -643,12 +644,12 @@ is no value there. In languages with null, variables can always be in one of
 two states: null or not-null.
 -->
 
-Les langages de programmation sont souvent conçus pour les fonctionnalités que
-vous souhaitez implémenter, mais les fonctionnalités que vous refusez sont elles
+La conception d'un langage de programmation est souvent pensée en fonction des
+fonctionnalités qu'on inclut, mais les fonctionnalités qu'on refuse sont elles
 aussi importantes. Rust n'a pas de fonctionnalité *null* qu'ont de nombreux
 langages. *Null* est une valeur qui signifie qu'il n'y a pas de valeur à cet
 endroit. Avec les langages qui utilisent null, les variables peuvent toujours
-être dans deux états : nulle ou non nulle.
+être dans deux états : null ou non null.
 
 <!--
 In his 2009 presentation “Null References: The Billion Dollar Mistake,” Tony
@@ -656,7 +657,7 @@ Hoare, the inventor of null, has this to say:
 -->
 
 Dans sa thèse de 2009 “Null References: The Billion Dollar Mistake” (les
-références nulles : l'erreur aux milliards de dollars), Tony Hoare, l'inventeur
+références nulles : l'erreur à un milliard de dollars), Tony Hoare, l'inventeur
 de null, a écrit ceci :
 
 <!--
@@ -670,15 +671,15 @@ de null, a écrit ceci :
 > the last forty years.
 -->
 
-> Je l'appelle mon erreur aux milliards de dollars. A cette époque, je concevais
-> le premier système de type exhaustif pour des références dans un langage
-> orienté objet. Mon objectif était d'assurer que toutes les utilisations des
-> références étaient totalement sûres, avec une vérification automatique du
-> compilateur. Mais je n'ai pas pu résister à la tentation de pouvoir utiliser
-> la référence nulle, simplement parce que c'était simple à implémenter. Cela
-> a conduit à d'innombrables erreurs, vulnérabilités, et pannes systèmes, qui
-> ont probablement causé quelques milliards de dollars de douleurs et de
-> dommages au cours des quarante dernières années.
+> Je l'appelle mon erreur à un milliard de dollars. À cette époque, je concevais
+> le premier système de type complet pour des références dans un langage orienté
+> objet. Mon objectif était de garantir que toutes les utilisations des
+> références soient totalement sûres, et soient vérifiées automatiquement par le
+> compilateur. Mais je n'ai pas pu résister à la tentation d'inclure la
+> référence nulle, simplement parce que c'était si simple à implémenter. Cela a
+> conduit à d'innombrables erreurs, vulnérabilités, et pannes systèmes, qui ont
+> probablement causé un milliard de dollars de dommages au cours des quarante
+> dernières années.
 
 <!--
 The problem with null values is that if you try to use a null value as a
@@ -696,8 +697,9 @@ However, the concept that null is trying to express is still a useful one: a
 null is a value that is currently invalid or absent for some reason.
 -->
 
-Cependant, le concept que null essaye de traduire reste utile : un null est une
-valeur qui est actuellement invalide ou absente pour une raison ou une autre.
+Cependant, le concept que null essaye d'exprimer reste utile : une valeur nulle
+est une valeur qui est actuellement invalide ou absente pour une raison ou une
+autre.
 
 <!--
 The problem isn’t really with the concept but with the particular
@@ -707,11 +709,11 @@ that can encode the concept of a value being present or absent. This enum is
 as follows:
 -->
 
-Le problème ne vient pas vraiment du concept, mais de son traitement au
-cas-par-cas. C'est pourquoi Rust n'a pas de valeurs nulles, mais il a une
-énumération qui décrit le concept d'avoir une valeur qui peut être présente ou
-absente. Cette énumération est `Option<T>`, et est [définie dans la bibliothèque
-standard][option]<!-- ignore --> comme ci-dessous :
+Le problème ne vient pas vraiment du concept, mais de son implémentation. C'est
+pourquoi Rust n'a pas de valeurs nulles, mais il a une énumération qui décrit le
+concept d'une valeur qui peut être soit présente, soit absente. Cette
+énumération est `Option<T>`, et elle est [définie dans la bibliothèque
+standard][option]<!-- ignore --> comme ci-dessous :
 
 <!--
 [option]: ../std/option/enum.Option.html
@@ -735,9 +737,9 @@ still variants of type `Option<T>`.
 -->
 
 L'énumération `Option<T>` est tellement utile qu'elle est intégrée dans l'étape
-préliminaire; vous n'avez pas besoin de l'importer explicitement dans la portée.
-De plus, voici ses variantes : vous pouvez utiliser directement `Some`
-(= quelque chose) et `None` (= rien) sans avoir le préfixe `Option::`.
+préliminaire ; vous n'avez pas besoin de l'importer explicitement dans la
+portée. De plus, voici ses variantes : vous pouvez utiliser directement `Some`
+(*quelque chose*) et `None` (*rien*) sans les préfixer par `Option::`.
 L'énumération `Option<T>` reste une énumération normale, et `Some(T)` ainsi que
 `None` sont toujours des variantes de type `Option<T>`.
 
@@ -750,7 +752,7 @@ using `Option` values to hold number types and string types
 -->
 
 La syntaxe `<T>` est une fonctionnalité de Rust que nous n'avons pas encore
-abordé. Il s'agit d'un paramètre de type générique, et nous verrons la
+abordée. Il s'agit d'un paramètre de type générique, et nous verrons la
 généricité plus en détail au chapitre 10. Pour le moment, dites-vous que ce
 `<T>` signifie que la variante `Some` de l'énumération `Option` peut stocker un
 élément de donnée de n'importe quel type. Voici quelques exemples d'utilisation
@@ -767,8 +769,8 @@ let absent_number: Option<i32> = None;
 -->
 
 ```rust
-let nombre_quelconque = Some(5);
-let chaine_quelconque = Some("a string");
+let un_nombre = Some(5);
+let une_chaine = Some("une chaîne");
 
 let nombre_absent: Option<i32> = None;
 ```
@@ -780,8 +782,8 @@ variant will hold by looking only at a `None` value.
 -->
 
 Si nous utilisons `None` plutôt que `Some`, nous devons indiquer à Rust quel
-type de `Option<T>` nous avons, car le compilateur ne peut pas en déduire le
-type que cette variante `Some` va stocker en considérant uniquement une valeur
+type de `Option<T>` nous avons, car le compilateur ne peut pas déduire le type
+que cette variante `Some` va stocker en considérant uniquement une valeur
 `None`.
 
 <!--
@@ -793,9 +795,8 @@ the same thing as null: we don’t have a valid value. So why is having
 
 Lorsque nous avons une valeur `Some`, nous savons que la valeur est présente et
 que la valeur est stockée dans le `Some`. Lorsque nous avons une valeur `None`,
-dans un certain sens, cela veut dire la même chose que null : nous n'avons pas
-de valeur valide. Donc pourquoi obtenir `Option<T>` est meilleur que d'avoir un
-null ?
+en quelque sorte, cela veut dire la même chose que null : nous n'avons pas une
+valeur valide. Donc pourquoi obtenir `Option<T>` est meilleur que d'avoir null ?
 
 <!--
 In short, because `Option<T>` and `T` (where `T` can be any type) are different
@@ -805,9 +806,10 @@ trying to add an `i8` to an `Option<i8>`:
 -->
 
 En bref, comme `Option<T>` et `T` (où `T` représente n'importe quel type) sont
-de type différent, le compilateur ne va pas nous autoriser à utiliser une valeur
-`Option<T>` comme si cela était bien une valeur valide. Par exemple, le code
-suivant ne se compile pas car il essaye d'ajouter un `i8` à une `Option<i8>` :
+de types différents, le compilateur ne va pas nous autoriser à utiliser une
+valeur `Option<T>` comme si cela était bien une valeur valide. Par exemple, le
+code suivant ne se compile pas car il essaye d'additionner un `i8` et une
+`Option<i8>` :
 
 <!--
 ```rust,ignore,does_not_compile
@@ -865,12 +867,12 @@ using the value.
 -->
 
 Intense ! Effectivement, ce message d'erreur signifie que Rust ne comprend pas
-comment additionner un `i8` et une `Option<i8>`, car ils sont de type
+comment additionner un `i8` et une `Option<i8>`, car ils sont de types
 différents. Quand nous avons une valeur d'un type comme `i8` avec Rust, le
 compilateur va s'assurer que nous avons toujours une valeur valide. Nous pouvons
 continuer en toute confiance sans avoir à vérifier que cette valeur n'est pas
-nulle avant de l'utiliser. Ce n'est que lorsque nous avons un `Option<i8>` (ou
-tout autre type de valeur avec laquelle nous travaillons) que nous devons nous
+nulle avant de l'utiliser. Ce n'est que lorsque nous avons une `Option<i8>` (ou
+tout autre type de valeur avec lequel nous travaillons) que nous devons nous
 inquiéter de ne pas avoir de valeur, et le compilateur va s'assurer que nous
 gérons ce cas avant d'utiliser la valeur.
 
@@ -882,9 +884,9 @@ is.
 -->
 
 Autrement dit, vous devez convertir une `Option<T>` en `T` pour pouvoir faire
-des opérations avec elle des valeurs de type `T`. Généralement, cela permet de
-résoudre l'un des problèmes les plus courants avec null : supposer que quelque
-chose n'est pas nul alors qu'en réalité cela l'est.
+avec elle des opérations du type `T`. Généralement, cela permet de résoudre l'un
+des problèmes les plus courants avec null : supposer qu'une valeur n'est pas
+nulle alors qu'en réalité, elle l'est.
 
 <!--
 Not having to worry about incorrectly assuming a not-null value helps you to be
@@ -897,16 +899,15 @@ deliberate design decision for Rust to limit null’s pervasiveness and increase
 the safety of Rust code.
 -->
 
-Le fait de ne pas avoir à se préoccuper de ne pas oublier de gérer des valeurs
-nulles vous aide à avoir plus de confiance en votre code. Lorsque vous pouvez
-produire une valeur qui peut potentiellement être nulle, vous devez l'indiquer
-en déclarant le type de cette valeur à `Option<T>`. Ensuite, quand vous
-utiliserez cette valeur, il vous faudra gérer explicitement le cas où cette
-valeur est nulle. Si vous utilisez une valeur qui n'est pas une `Option<T>`,
-alors vous *pouvez* considérer que cette valeur ne sera jamais nulle sans
-prendre de risques. Il s'agit d'un principe de conception de Rust qui a été
-intégré volontairement pour limiter l'omniprésence de null et d'augmenter la
-sécurité du code en Rust.
+Ne pas avoir à s'inquiéter que des valeurs nulles puissent être mal gérées vous
+aide à être plus confiant en votre code. Pour avoir une valeur qui peut
+potentiellement être nulle, vous devez l'indiquer explicitement en déclarant que
+le type de cette valeur est `Option<T>`. Ensuite, quand vous utiliserez cette
+valeur, il vous faudra gérer explicitement le cas où cette valeur est nulle. Si
+vous utilisez une valeur qui n'est pas une `Option<T>`, alors vous *pouvez*
+considérer que cette valeur ne sera jamais nulle sans prendre de risques. Il
+s'agit d'un choix de conception délibéré de Rust pour limiter l'omniprésence de
+null et augmenter la sécurité du code en Rust.
 
 <!--
 So, how do you get the `T` value out of a `Some` variant when you have a value
@@ -918,8 +919,8 @@ the methods on `Option<T>` will be extremely useful in your journey with Rust.
 
 Donc, comment récupérer la valeur de type `T` d'une variante `Some` quand vous
 avez une valeur de type `Option<T>` afin de l'utiliser ? L'énumération
-`Option<T>` a un large choix de méthodes qui plus ou moins utiles selon les cas;
-vous pouvez les découvrir dans [sa documentation][docs]<!-- ignore -->. Se
+`Option<T>` a un large choix de méthodes qui sont plus ou moins utiles selon les
+cas ; vous pouvez les découvrir dans [sa documentation][docs]<!-- ignore -->. Se
 familiariser avec les méthodes de `Option<T>` peut être très utile dans votre
 aventure avec Rust.
 
@@ -940,13 +941,12 @@ variant of the enum it has, and that code can use the data inside the matching
 value.
 -->
 
-De manière générale, dans le but d'utiliser une valeur de `Option<T>`, vous
-devez produire un code qui gère chaque variante. Vous voulez que du code soit
-exécuté uniquement quand vous avez une valeur `Some(T)`, et que ce code soit
-autorisé à utiliser le type `T` à l'intérieur. Vous voulez aussi qu'un autre
-code puisse être exécuté si vous avez une valeur `None`, et ce code n'aura pas
-de valeur de type `T` qui est disponible. L'expression `match` est une
-structure de contrôle qui fait bien ceci lorsqu'elle est utilisée avec les
-énumérations : elle va exécuter du code différent en fonction de quelle variante
-de l'énumération elle obtient, et ce code pourra utiliser la donnée présente
-dans la valeur correspondante.
+De manière générale, pour pouvoir utiliser une valeur de `Option<T>`, votre code
+doit gérer chaque variante. On veut que du code soit exécuté uniquement quand on
+a une valeur `Some(T)`, et que ce code soit autorisé à utiliser la valeur de
+type `T` à l'intérieur. On veut aussi qu'un autre code soit exécuté si on a une
+valeur `None`, et ce code n'aura pas de valeur de type `T` de disponible.
+L'expression `match` est une structure de contrôle qui fait bien ceci
+lorsqu'elle est utilisée avec les énumérations : elle va exécuter du code
+différent en fonction de quelle variante de l'énumération elle obtient, et ce
+code pourra utiliser la donnée présente dans la valeur correspondante.


### PR DESCRIPTION
I have proofread Chapter 06-01.
I used `sorte` rather than `type` to translate `kind` in order to avoid the confusion with data types (and because `type` is a keyword in Rust and thus, code that try use `type` as an identifier don't compile).
I made other changes as well.

Note that I won't have time to translate or proofread any more pages in the next few months.