### PR TITLE
Proofread ch09-02 (about Result)

### DIFF
--- a/FRENCH/listings/ch09-error-handling/listing-09-04/output.txt
+++ b/FRENCH/listings/ch09-error-handling/listing-09-04/output.txt
@@ -2,5 +2,5 @@ $ cargo run
    Compiling error-handling v0.1.0 (file:///projects/error-handling)
     Finished dev [unoptimized + debuginfo] target(s) in 0.73s
      Running `target/debug/error-handling`
-thread 'main' panicked at 'Problem opening the file: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/main.rs:8:23
+thread 'main' panicked at 'Erreur d'ouverture du fichier : Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/main.rs:8:24
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/FRENCH/listings/ch09-error-handling/listing-09-04/src/main.rs
+++ b/FRENCH/listings/ch09-error-handling/listing-09-04/src/main.rs
@@ -5,6 +5,6 @@ fn main() {
 
     let f = match f {
         Ok(fichier) => fichier,
-        Err(erreur) => panic!("Erreur lors de l'ouverture du fichier : {:?}", erreur),
+        Err(erreur) => panic!("Erreur d'ouverture du fichier : {:?}", erreur),
     };
 }

--- a/FRENCH/listings/ch09-error-handling/listing-09-05/src/main.rs
+++ b/FRENCH/listings/ch09-error-handling/listing-09-05/src/main.rs
@@ -9,9 +9,11 @@ fn main() {
         Err(erreur) => match erreur.kind() {
             ErrorKind::NotFound => match File::create("hello.txt") {
                 Ok(fc) => fc,
-                Err(e) => panic!("Erreur lors de la création du fichier : {:?}", e),
+                Err(e) => panic!("Erreur de création du fichier : {:?}", e),
             },
-            autre_erreur => panic!("Erreur lors de l'ouverture du fichier : {:?}", autre_erreur),
+            autre_erreur => {
+                panic!("Erreur d'ouverture du fichier : {:?}", autre_erreur)
+            }
         },
     };
 }

--- a/FRENCH/listings/ch09-error-handling/listing-09-06/src/main.rs
+++ b/FRENCH/listings/ch09-error-handling/listing-09-06/src/main.rs
@@ -3,11 +3,11 @@ use std::fs::File;
 use std::io;
 use std::io::Read;
 
-fn read_username_from_file() -> Result<String, io::Error> {
+fn lire_pseudo_depuis_fichier() -> Result<String, io::Error> {
     let f = File::open("hello.txt");
 
     let mut f = match f {
-        Ok(file) => file,
+        Ok(fichier) => fichier,
         Err(e) => return Err(e),
     };
 
@@ -21,5 +21,6 @@ fn read_username_from_file() -> Result<String, io::Error> {
 // ANCHOR_END: here
 
 fn main() {
-    let username = read_username_from_file().expect("Unable to get username");
+    let pseudo =
+        lire_pseudo_depuis_fichier().expect("Échec de lecture du pseudo");
 }

--- a/FRENCH/listings/ch09-error-handling/listing-09-07/src/main.rs
+++ b/FRENCH/listings/ch09-error-handling/listing-09-07/src/main.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io;
 use std::io::Read;
 
-fn read_username_from_file() -> Result<String, io::Error> {
+fn lire_pseudo_depuis_fichier() -> Result<String, io::Error> {
     let mut f = File::open("hello.txt")?;
     let mut s = String::new();
     f.read_to_string(&mut s)?;
@@ -12,5 +12,6 @@ fn read_username_from_file() -> Result<String, io::Error> {
 // ANCHOR_END: here
 
 fn main() {
-    let username = read_username_from_file().expect("Unable to get username");
+    let pseudo =
+        lire_pseudo_depuis_fichier().expect("Échec de lecture du pseudo");
 }

--- a/FRENCH/listings/ch09-error-handling/listing-09-08/src/main.rs
+++ b/FRENCH/listings/ch09-error-handling/listing-09-08/src/main.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io;
 use std::io::Read;
 
-fn read_username_from_file() -> Result<String, io::Error> {
+fn lire_pseudo_depuis_fichier() -> Result<String, io::Error> {
     let mut s = String::new();
 
     File::open("hello.txt")?.read_to_string(&mut s)?;
@@ -13,5 +13,6 @@ fn read_username_from_file() -> Result<String, io::Error> {
 // ANCHOR_END: here
 
 fn main() {
-    let username = read_username_from_file().expect("Unable to get username");
+    let pseudo =
+        lire_pseudo_depuis_fichier().expect("Échec de lecture du pseudo");
 }

--- a/FRENCH/listings/ch09-error-handling/listing-09-09/src/main.rs
+++ b/FRENCH/listings/ch09-error-handling/listing-09-09/src/main.rs
@@ -2,11 +2,12 @@
 use std::fs;
 use std::io;
 
-fn read_username_from_file() -> Result<String, io::Error> {
+fn lire_pseudo_depuis_fichier() -> Result<String, io::Error> {
     fs::read_to_string("hello.txt")
 }
 // ANCHOR_END: here
 
 fn main() {
-    let username = read_username_from_file().expect("Unable to get username");
+    let pseudo =
+        lire_pseudo_depuis_fichier().expect("Échec de lecture du pseudo");
 }

--- a/FRENCH/listings/ch09-error-handling/no-listing-03-closures/src/main.rs
+++ b/FRENCH/listings/ch09-error-handling/no-listing-03-closures/src/main.rs
@@ -5,10 +5,10 @@ fn main() {
     let f = File::open("hello.txt").unwrap_or_else(|erreur| {
         if erreur.kind() == ErrorKind::NotFound {
             File::create("hello.txt").unwrap_or_else(|erreur| {
-                panic!("Erreur lors de la création du fichier : {:?}", erreur);
+                panic!("Erreur de création du fichier : {:?}", erreur);
             })
         } else {
-            panic!("Erreur lors de l'ouverture du fichier : {:?}", erreur);
+            panic!("Erreur d'ouverture du fichier : {:?}", erreur);
         }
     });
 }

--- a/FRENCH/listings/ch09-error-handling/no-listing-05-expect/src/main.rs
+++ b/FRENCH/listings/ch09-error-handling/no-listing-05-expect/src/main.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
 
 fn main() {
-    let f = File::open("hello.txt").expect("Echec à l'ouverture de hello.txt");
+    let f = File::open("hello.txt").expect("Échec à l'ouverture de hello.txt");
 }

--- a/FRENCH/src/ch09-02-recoverable-errors-with-result.md
+++ b/FRENCH/src/ch09-02-recoverable-errors-with-result.md
@@ -13,11 +13,11 @@ file instead of terminating the process.
 -->
 
 La plupart des erreurs ne sont pas assez graves au point d'arrêter complètement
-le programme. Parfois, lorsque une fonction échoue, c'est pour une raison que
-vous pouvez facilement comprendre et pour laquelle agir en conséquence. Par exemple, si vous
-essayez d'ouvrir un fichier et que l'opération échoue parce que le fichier
-n'existe pas, vous pourriez vouloir créer le fichier plutôt que d'arrêter le
-processus.
+le programme. Parfois, lorsqu'une fonction échoue, c'est pour une raison que
+vous pouvez facilement comprendre et pour laquelle vous pouvez agir en
+conséquence. Par exemple, si vous essayez d'ouvrir un fichier et que l'opération
+échoue parce que le fichier n'existe pas, vous pourriez vouloir créer le fichier
+plutôt que d'arrêter le processus.
 
 <!--
 Recall from [“Handling Potential Failure with the `Result`
@@ -25,10 +25,9 @@ Type”][handle_failure]<!-- ignore -- > in Chapter 2 that the `Result` enum is
 defined as having two variants, `Ok` and `Err`, as follows:
 -->
 
-Souvenez-vous de la section
-[“Gérer les erreurs potentielles avec le type `Result`”][handle_failure]<!-- ignore -->
-du chapitre 2 lorsque l'énumération `Result` pouvait avoir deux variantes, `Ok`
-et `Err`, comme ci-dessous :
+Souvenez-vous de la section [“Gérer les erreurs potentielles avec le type
+`Result`”][handle_failure]<!-- ignore --> du chapitre 2 que l'énumération
+`Result` possède deux variantes, `Ok` et `Err`, comme ci-dessous :
 
 <!--
 [handle_failure]: ch02-00-guessing-game-tutorial.html#handling-potential-failure-with-the-result-type
@@ -63,15 +62,15 @@ library has defined on it in many different situations where the successful
 value and error value we want to return may differ.
 -->
 
-Le `T` et `E` sont des paramètres de type génériques : nous allons parler plus
-en détail des génériques au chapitre 10. Tout ce que vous avez besoin de savoir
+Le `T` et le `E` sont des paramètres de type génériques : nous parlerons plus en
+détail de la généricité au chapitre 10. Tout ce que vous avez besoin de savoir
 pour le moment, c'est que `T` représente le type de valeur imbriquée dans la
 variante `Ok` qui sera retournée dans le cas d'un succès, et `E` représente le
 type d'erreur imbriquée dans la variante `Err` qui sera retournée dans le cas
-d'un échec. Comme `Result` a ces types de paramètres génériques, nous pouvons
-utiliser le type `Result` et les fonctions que la bibliothèque standard qui lui
-ont été associées pour différentes situations où la valeur de succès et la
-valeur d'erreur peuvent être différentes.
+d'un échec. Comme `Result` a ces paramètres de type génériques, nous pouvons
+utiliser le type `Result` et les fonctions que la bibliothèque standard lui a
+associées dans différentes situations où la valeur de succès et la valeur
+d'erreur peuvent varier.
 
 <!--
 Let’s call a function that returns a `Result` value because the function could
@@ -79,7 +78,7 @@ fail. In Listing 9-3 we try to open a file.
 -->
 
 Utilisons une fonction qui retourne une valeur de type `Result` car la fonction
-peut échouer. Dans l'encart 9-3 nous essayons d'ouvrir un fichier :
+peut échouer. Dans l'encart 9-3, nous essayons d'ouvrir un fichier :
 
 <!--
 <span class="filename">Filename: src/main.rs</span>
@@ -114,15 +113,15 @@ isn’t of type `u32`, so let’s change the `let f` statement to this:
 -->
 
 Comment savons-nous que `File::open` retourne un `Result` ? Nous pouvons
-regarder la
-[documentation de l'API de la bibliothèque standard](https://doc.rust-lang.org/std/index.html)<!-- ignore -->,
-ou nous pouvons demander au compilateur ! Si nous appliquons à `f` une
-annotation de type dont nous savons qu'elle n'est *pas* le type de retour de la
-fonction et que nous essayons ensuite de compiler le code, le compilateur va
-nous dire que les types ne correspondent pas. Le message d'erreur va ensuite
-nous dire *quel est le type* de `f`. Essayons cela ! Nous savons que le
-retour de `File::open` n'est pas du type `u32`, alors essayons de changer
-l'instruction `let f` par ceci :
+consulter la [documentation de l'API de la bibliothèque
+standard](https://doc.rust-lang.org/std/index.html)<!-- ignore -->, ou nous
+pouvons demander au compilateur ! Si nous appliquons à `f` une annotation de
+type dont nous savons qu'elle n'est *pas* le type de retour de la fonction et
+que nous essayons ensuite de compiler le code, le compilateur va nous dire que
+les types ne correspondent pas. Le message d'erreur va ensuite nous dire *quel
+est le type* de `f`. Essayons cela ! Nous savons que le type de retour de
+`File::open` n'est pas `u32`, alors essayons de changer l'instruction `let f`
+par ceci :
 
 <!--
 ```rust,ignore,does_not_compile
@@ -138,7 +137,7 @@ l'instruction `let f` par ceci :
 Attempting to compile now gives us the following output:
 -->
 
-La compilation nous donne maintenant le résultat suivant :
+Tenter de compiler ce code nous donne maintenant le résultat suivant :
 
 <!--
 ```console
@@ -157,7 +156,7 @@ value, `std::fs::File`, which is a file handle. The type of `E` used in the
 error value is `std::io::Error`.
 -->
 
-Cela nous dit que le retour de la fonction `File::open` est du type
+Cela nous dit que le type de retour de la fonction `File::open` est de la forme
 `Result<T, E>`. Le paramètre générique `T` a été remplacé dans ce cas par le
 type en cas de succès, `std::fs::File`, qui permet d'interagir avec le fichier.
 Le `E` utilisé pour la valeur d'erreur est du type `std::io::Error`.
@@ -173,11 +172,11 @@ conveys.
 -->
 
 Ce type de retour veut dire que l'appel à `File::open` peut réussir et nous
-retourner un manipulateur de fichier qui peut nous permettre de le lire ou
-l'écrire. L'utilisation de cette fonction peut aussi échouer : par exemple, le
-fichier peut ne pas exister, ou nous n'avons pas le droit d'accéder au fichier.
-La fonction `File::open` doit avoir un moyen de nous dire si son utilisation a
-réussi ou échoué et en même temps nous fournir soit le manipulateur de fichier
+retourner un manipulateur de fichier qui peut nous permettre de le lire ou d'y
+écrire. L'utilisation de cette fonction peut aussi échouer : par exemple, si le
+fichier n'existe pas, ou si nous n'avons pas le droit d'accéder au fichier. La
+fonction `File::open` doit avoir un moyen de nous dire si son utilisation a
+réussi ou échoué et en même temps nous fournir soit le manipulateur de fichier,
 soit des informations sur l'erreur. C'est exactement ces informations que
 l'énumération `Result` se charge de nous transmettre.
 
@@ -188,7 +187,7 @@ the value in `f` will be an instance of `Err` that contains more information
 about the kind of error that happened.
 -->
 
-Dans le cas où `File::open` réussit, la valeur que nous obtenons dans la
+Dans le cas où `File::open` réussit, la valeur que nous obtiendrons dans la
 variable `f` sera une instance de `Ok` qui contiendra un manipulateur de
 fichier. Dans le cas où cela échoue, la valeur dans `f` sera une instance de
 `Err` qui contiendra plus d'information sur le type d'erreur qui a eu lieu.
@@ -201,9 +200,9 @@ Chapter 6.
 -->
 
 Nous avons besoin d'ajouter différentes actions dans le code de l'encart 9-3 en
-fonction de la valeur que `File::open` a retourné. L'encart 9-4 montre une façon
-de gérer `Result` en utilisant un outil basique, l'expression `match` que nous
-avons vu au chapitre 6.
+fonction de la valeur que `File::open` retourne. L'encart 9-4 montre une façon
+de gérer le `Result` en utilisant un outil basique, l'expression `match` que
+nous avons vue au chapitre 6.
 
 <!--
 <span class="filename">Filename: src/main.rs</span>
@@ -226,8 +225,8 @@ avons vu au chapitre 6.
 `Result` variants that might be returned</span>
 -->
 
-<span class="caption">Encart 9-4: utilisation de l'expression `match` pour
-gérer les variantes que `Result` pourrait retourner</span>
+<span class="caption">Encart 9-4 : utilisation de l'expression `match` pour
+gérer les variantes de `Result` qui peuvent être retournées</span>
 
 <!--
 Note that, like the `Option` enum, the `Result` enum and its variants have been
@@ -235,8 +234,8 @@ brought into scope by the prelude, so we don’t need to specify `Result::`
 before the `Ok` and `Err` variants in the `match` arms.
 -->
 
-Remarquez que comme l'énumération `Option`, l'énumération `Result` et ses
-variantes ont été importés par l'étape préliminaire, donc vous n'avez pas
+Remarquez que, tout comme l'énumération `Option`, l'énumération `Result` et ses
+variantes ont été importées par l'étape préliminaire, donc vous n'avez pas
 besoin de préciser `Result::` devant les variantes `Ok` et `Err` dans les
 branches du `match`.
 
@@ -247,9 +246,9 @@ variable `f`. After the `match`, we can use the file handle for reading or
 writing.
 -->
 
-Ici nous indiquons à Rust que quand le résultat est `Ok`, il faut sortir la
-valeur `fichier` de la variante `Ok`, et nous assignons ensuite cette valeur à
-la variable `f`. Après le `match`, nous pourrons ensuite utiliser le
+Ici, nous indiquons à Rust que quand le résultat est `Ok`, il faut retourner la
+valeur `fichier` contenue dans la variante `Ok`, et nous assignons ensuite cette
+valeur à la variable `f`. Après le `match`, nous pourrons ensuite utiliser le
 manipulateur de fichier pour lire ou écrire.
 
 <!--
@@ -286,7 +285,7 @@ passé.
 ### Matching on Different Errors
 -->
 
-### Tester les différentes erreurs
+### Gérer les différentes erreurs
 
 <!--
 The code in Listing 9-4 will `panic!` no matter why `File::open` failed. What
@@ -299,14 +298,14 @@ at Listing 9-5, which adds an inner `match` expression.
 -->
 
 Le code dans l'encart 9-4 va faire un `panic!` peu importe la raison de l'échec
-de `File::open`. Ce que nous voudrions plutôt faire est de réagir différemment en
-fonction de différents cas d'erreurs : si `File::open` a échoué parce que le
-fichier n'existe pas, nous voulons créer le fichier et renvoyer le manipulateur
+de `File::open`. Ce que nous voudrions plutôt faire est de réagir différemment
+en fonction de différents cas d'erreurs : si `File::open` a échoué parce que le
+fichier n'existe pas, nous voulons créer le fichier et retourner le manipulateur
 de fichier pour ce nouveau fichier. Si `File::open` échoue pour toute autre
 raison, par exemple si nous n'avons pas l'autorisation d'ouvrir le fichier,
 nous voulons quand même que le code lance un `panic!` de la même manière qu'il
-l'a fait dans l'encart 9-4. Dans l'encart 9-5, nous avons ajouté un nouveau cas
-au bloc `match` :
+l'a fait dans l'encart 9-4. Dans l'encart 9-5, nous avons ajouté une expression
+`match` imbriquée :
 
 <!--
 <span class="filename">Filename: src/main.rs</span>
@@ -335,7 +334,7 @@ different ways</span>
 -->
 
 <span class="caption">Encart 9-5 : gestion des différents cas d'erreurs avec des
-actions différentes.</span>
+actions différentes</span>
 
 <!--
 The type of the value that `File::open` returns inside the `Err` variant is
@@ -350,14 +349,14 @@ also have an inner match on `error.kind()`.
 
 La valeur de retour de `File::open` logée dans la variante `Err` est de type
 `io::Error`, qui est une structure fournie par la bibliothèque standard. Cette
-structure a une méthode `kind` que nous pouvons utiliser pour obtenir un retour
+structure a une méthode `kind` que nous pouvons appeler pour obtenir une valeur
 de type `io::ErrorKind`. L'énumération `io::ErrorKind` est fournie elle aussi
-par la bibliothèque standard qui embarque des variantes qui représentent
-différents types d'erreurs qui pourraient résulter d'une opération provenant du
-module `io`. La variante que nous voulons utiliser est `ErrorKind::NotFound`,
-qui nous informe que le fichier que nous essayons d'ouvrir n'existe pas encore.
-Donc nous utilisons `match` sur `f`, mais nous avons dans celle-ci une autre
-`match` sur `erreur.kind()`.
+par la bibliothèque standard et a des variantes qui représentent les différents
+types d'erreurs qui pourraient résulter d'une opération provenant du module
+`io`. La variante que nous voulons utiliser est `ErrorKind::NotFound`, qui
+indique que le fichier que nous essayons d'ouvrir n'existe pas encore. Donc nous
+utilisons `match` sur `f`, mais nous avons dans celle-ci un autre `match` sur
+`erreur.kind()`.
 
 <!--
 The condition we want to check in the inner match is whether the value returned
@@ -373,9 +372,9 @@ Nous souhaitons vérifier dans le `match` interne si la valeur de retour de
 `error.kind()` est la variante `NotFound` de l'énumération `ErrorKind`. Si c'est
 le cas, nous essayons de créer le fichier avec `File::create`. Cependant, comme
 `File::create` peut aussi échouer, nous avons besoin d'une seconde branche dans
-le `match` à l'intérieur. Lorsque le fichier ne peut pas être créé, un message
+le `match` interne. Lorsque le fichier ne peut pas être créé, un message
 d'erreur différent est affiché. La seconde branche du `match` principal reste
-inchangé, donc le programme panique lorsqu'on rencontre une autre erreur que
+inchangée, donc le programme panique lorsqu'on rencontre une autre erreur que
 l'absence de fichier.
 
 <!--
@@ -387,11 +386,11 @@ more seasoned Rustacean might write this code instead of Listing 9-5:
 -->
 
 Cela commence à faire beaucoup de `match` ! L'expression `match` est très utile
-mais est aussi assez rudimentaire. Dans le chapitre 13, vous allez en apprendre plus
+mais est aussi assez rudimentaire. Dans le chapitre 13, vous en apprendrez plus
 sur les fermetures ; le type `Result<T, E>` a de nombreuses méthodes qui
-acceptent une fermeture et qui sont implémentés en utilisant des expressions
-`match`. L'utilisation de ces méthodes vont rendre votre code plus concis. Un
-Rustacé plus habitué écrira ce code plutôt que celui de l'encart 9-5 :
+acceptent une fermeture et qui sont implémentées en utilisant des expressions
+`match`. L'utilisation de ces méthodes va rendre votre code plus concis. Un
+Rustacé plus chevronné écrira ce code plutôt que celui de l'encart 9-5 :
 
 <!--
 ```rust,ignore
@@ -416,13 +415,13 @@ contient aucune expression `match` et est plus facile à lire. Revenez sur cet
 exemple après avoir lu le chapitre 13, et renseignez-vous sur la méthode
 `unwrap_or_else` dans la documentation de la bibliothèque standard. De
 nombreuses méthodes de ce type peuvent clarifier de grosses expressions `match`
-lorsque vous traitez les erreurs.
+imbriquées lorsque vous traitez les erreurs.
 
 <!--
 ### Shortcuts for Panic on Error: `unwrap` and `expect`
 -->
 
-### Raccourci pour faire un Panic lors d'une erreur : `unwrap` et `expect`
+### Raccourcis pour faire un panic lors d'une erreur : `unwrap` et `expect`
 
 <!--
 Using `match` works well enough, but it can be a bit verbose and doesn’t always
@@ -436,12 +435,12 @@ call the `panic!` macro for us. Here is an example of `unwrap` in action:
 
 L'utilisation de `match` fonctionne assez bien, mais elle peut être un peu
 verbeuse et ne communique pas forcément bien son intention. Le type
-`Result<T, R>` a de nombreuses méthodes qui lui ont été définies pour différents
+`Result<T, E>` a de nombreuses méthodes qui lui ont été définies pour différents
 cas. Une de ces méthodes, qui s'appelle `unwrap`, a été implémentée comme
-l'expression `match` que nous avons écrit dans l'encart 9-4. Si la valeur de
-`Result` est une variante de `Ok`, `unwrap` va retourner la valeur dans le
-`Ok`. Si le `Result` est une variante de `Err`, `unwrap` va appeler la macro
-`panic!` pour nous. Voici un exemple de `unwrap` à l'action :
+l'expression `match` que nous avons écrite dans l'encart 9-4. Si la valeur de
+`Result` est la variante `Ok`, `unwrap` va retourner la valeur contenue dans le
+`Ok`. Si le `Result` est la variante `Err`, `unwrap` va appeler la macro
+`panic!` pour nous. Voici un exemple de `unwrap` en action :
 
 <!--
 <span class="filename">Filename: src/main.rs</span>
@@ -464,8 +463,9 @@ If we run this code without a *hello.txt* file, we’ll see an error message fro
 the `panic!` call that the `unwrap` method makes:
 -->
 
-Si nous exécutons ce code sans le fichier *hello.txt*, nous allons voir un
-message d'erreur suite à l'appel à `panic!` que la méthode `unwrap` a fait :
+Si nous exécutons ce code alors qu'il n'y a pas de fichier *hello.txt*, nous
+allons voir un message d'erreur suite à l'appel à `panic!` que la méthode
+`unwrap` a fait :
 
 <!--
 ```text
@@ -491,8 +491,8 @@ panic easier. The syntax of `expect` looks like this:
 L'autre méthode, `expect`, qui ressemble à `unwrap`, nous donne la possibilité
 de définir le message d'erreur du `panic!`. Utiliser `expect` plutôt que
 `unwrap` et lui fournir un bon message d'erreur permet de mieux exprimer le
-problème et faciliter la recherche de la source d'erreur. La syntaxe de `expect`
-est la suivante :
+problème et faciliter la recherche de la source d'un panic. La syntaxe de
+`expect` est la suivante :
 
 <!--
 <span class="filename">Filename: src/main.rs</span>
@@ -519,9 +519,9 @@ will be the parameter that we pass to `expect`, rather than the default
 
 Nous utilisons `expect` de la même manière que `unwrap` : pour retourner le
 manipulateur de fichier ou appeler la macro `panic!`. Le message d'erreur
-utilisé par `expect` lors de son appel au `panic!` sera le paramètre que nous
-avons passé à `expect`, plutôt que le message par défaut de `panic!`
-qu'utilise `unwrap`. Voici ce que cela donne :
+utilisé par `expect` lors de son appel à `panic!` sera le paramètre que nous
+avons passé à `expect`, plutôt que le message par défaut de `panic!` qu'utilise
+`unwrap`. Voici ce que cela donne :
 
 <!--
 ```text
@@ -531,7 +531,7 @@ thread 'main' panicked at 'Failed to open hello.txt: Error { repr: Os { code:
 -->
 
 ```text
-thread 'main' panicked at 'Echec à l'ouverture de hello.txt: Error { repr: Os {
+thread 'main' panicked at 'Échec à l'ouverture de hello.txt: Error { repr: Os {
 code: 2, message: "No such file or directory" } }', src/libcore/result.rs:906:4
 ```
 
@@ -543,17 +543,17 @@ figure out exactly which `unwrap` is causing the panic because all `unwrap`
 calls that panic print the same message.
 -->
 
-Comme ce message d'erreur commence par le texte que nous avons précisé, `Echec à
-l'ouverture de hello.txt`, ce sera plus facile de trouver où se situe ce message
-d'erreur dans le code. Si nous utilisons `unwrap` à plusieurs endroits, cela
-peut prendre plus de temps de comprendre exactement quel `unwrap` a causé la
-panique, car tous les appels aux `unwrap` vont afficher le même message.
+Comme ce message d'erreur commence par le texte que nous avons précisé, `Échec à
+l'ouverture de hello.txt`, ce sera plus facile de trouver là d'où provient ce
+message d'erreur dans le code. Si nous utilisons `unwrap` à plusieurs endroits,
+cela peut prendre plus de temps de comprendre exactement quel `unwrap` a causé
+le panic, car tous les appels à `unwrap` vont afficher le même message.
 
 <!--
 ### Propagating Errors
 -->
 
-### Propager les Erreurs
+### Propager les erreurs
 
 <!--
 When you’re writing a function whose implementation calls something that might
@@ -577,9 +577,9 @@ the file doesn’t exist or can’t be read, this function will return those err
 to the code that called this function.
 -->
 
-Par exemple, l'encart 9-6 montre une fonction qui lit le nom d'utilisateur à
-partir d'un fichier. Si ce fichier n'existe pas ou ne peut pas être lu, cette
-fonction va retourner ces erreurs au code qui a appelé cette fonction.
+Par exemple, l'encart 9-6 montre une fonction qui lit un pseudo à partir d'un
+fichier. Si ce fichier n'existe pas ou ne peut pas être lu, cette fonction va
+retourner ces erreurs au code qui a appelé cette fonction.
 
 <!--
 <span class="filename">Filename: src/main.rs</span>
@@ -608,8 +608,8 @@ don't want to include it for rustdoc testing purposes. -- >
 calling code using `match`</span>
 -->
 
-<span class="caption">Encart 9-6 : une fonction qui retourne les erreurs au
-code qui l'appelle en utilisant `match`</span>
+<span class="caption">Encart 9-6 : une fonction qui retourne les erreurs au code
+qui l'appelle en utilisant `match`</span>
 
 <!--
 This function can be written in a much shorter way, but we’re going to start by
@@ -632,20 +632,20 @@ method.
 
 Cette fonction peut être écrite de façon plus concise, mais nous avons décidé de
 commencer par faire un maximum de choses manuellement pour découvrir la gestion
-d'erreurs ; mais à la fin, nous verrons comment raccourcir le code. Commençons par
-regarder le type de retour de la fonction : `Result<String, io::Error>`. Cela
-signifie que la fonction retourne une valeur de type `Result<T, E>` où le
+d'erreurs ; mais à la fin, nous verrons comment raccourcir le code. Commençons
+par regarder le type de retour de la fonction : `Result<String, io::Error>`.
+Cela signifie que la fonction retourne une valeur de type `Result<T, E>` où le
 paramètre générique `T` a été remplacé par le type `String` et le paramètre
 générique `E` a été remplacé par le type `io::Error`. Si cette fonction réussit
-avec succès, le code qui appelle cette fonction va obtenir une valeur `Ok` qui
-contient un `String`, le nom d'utilisateur que cette fonction lit dans le
-fichier. Si cette fonction rencontre un problème, le code qui appelle cette
-fonction va obtenir une valeur `Err` qui contient une instance de `io::Error`
-qui donne plus d'informations sur la raison du problème. Nous avons choisi
-`io::Error` comme type de retour de cette fonction parce qu'il se trouve que
-c'est le type d'erreur de retour pour toutes les opérations qui peuvent échouer
-que l'on utilise dans le corps de cette fonction : la fonction `File::open` et
-la méthode `read_to_string`.
+sans problème, le code qui appelle cette fonction va obtenir une valeur `Ok` qui
+contient une `String`, le pseudo que cette fonction lit dans le fichier. Si
+cette fonction rencontre un problème, le code qui appelle cette fonction va
+obtenir une valeur `Err` qui contient une instance de `io::Error` qui donne plus
+d'informations sur la raison du problème. Nous avons choisi `io::Error` comme
+type de retour de cette fonction parce qu'il se trouve que c'est le type
+d'erreur de retour pour les deux opérations qui peuvent échouer que l'on utilise
+dans le corps de cette fonction : la fonction `File::open` et la méthode
+`read_to_string`.
 
 <!--
 The body of the function starts by calling the `File::open` function. Then we
@@ -657,12 +657,12 @@ the file handle in the variable `f` and continue.
 -->
 
 Le corps de la fonction commence par appeler la fonction `File::open`. Ensuite,
-nous gérons la valeur `Result` retourné, avec un `match` similaire au `match`
-dans l'encart 9-4, mais, au lieu d'appeler `panic!` dans le cas de `Err`, nous
-retournons prématurément le résultat de la fonction avec la valeur d'erreur de
-`File::open` au code appelant avec la valeur d'erreur de cette fonction. Si
-`File::open` réussit, nous enregistrons le manipulateur de fichier dans la
-variable `f` et nous continuons.
+nous gérons la valeur `Result` retournée, avec un `match` similaire au `match`
+de l'encart 9-4, sauf qu'au lieu d'appeler `panic!` dans le cas de `Err`, nous
+sortons prématurément de la fonction en passant la valeur d'erreur de
+`File::open` au code appelant comme valeur de retour de cette fonction. Si
+`File::open` réussit, nous stockons le manipulateur de fichier dans la variable
+`f` et nous continuons.
 
 <!--
 Then we create a new `String` in variable `s` and call the `read_to_string`
@@ -677,18 +677,18 @@ returned the error value in the `match` that handled the return value of
 is the last expression in the function.
 -->
 
-Ensuite, nous créons un nouveau `String` dans la variable `s` et nous appelons
+Ensuite, nous créons une nouvelle `String` dans la variable `s` et nous appelons
 la méthode `read_to_string` sur le manipulateur de fichier `f` pour extraire le
 contenu du fichier dans `s`. La méthode `read_to_string` retourne aussi un
-`Result` car elle peut échouer, même si `File::open` réussit. Nous avons donc
+`Result` car elle peut échouer, même si `File::open` a réussi. Nous avons donc
 besoin d'un nouveau `match` pour gérer ce `Result` : si `read_to_string`
-réussit, alors notre fonction a réussi, et nous retournons le nom d'utilisateur
-présent dans le contenu du fichier qui est maintenant intégré dans un `Ok`,
-lui-même stocké dans `s`. Si `read_to_string` échoue, nous retournons la valeur
-d'erreur de la même façon que nous avons retourné la valeur d'erreur dans le
-`match` qui gérait la valeur de retour de `File::open`. Cependant, nous n'avons
-pas besoin d'écrire explicitement `return`, car c'est la dernière expression
-de la fonction.
+réussit, alors notre fonction a réussi, et nous retournons le pseudo que nous
+avons extrait du fichier qui est maintenant intégré dans un `Ok`, lui-même
+stocké dans `s`. Si `read_to_string` échoue, nous retournons la valeur d'erreur
+de la même façon que nous avons retourné la valeur d'erreur dans le `match` qui
+gérait la valeur de retour de `File::open`. Cependant, nous n'avons pas besoin
+d'écrire explicitement `return`, car c'est la dernière expression de la
+fonction.
 
 <!--
 The code that calls this code will then handle getting either an `Ok` value
@@ -702,14 +702,14 @@ it to handle appropriately.
 -->
 
 Le code qui appelle ce code va devoir ensuite gérer les cas où il récupère une
-valeur `Ok` qui contient un nom d'utilisateur, ou une valeur `Err` qui contient
-une `io::Error`. Nous ne savons pas ce que va faire le code appelant avec ces
+valeur `Ok` qui contient un pseudo, ou une valeur `Err` qui contient une
+`io::Error`. Nous ne savons pas ce que va faire le code appelant avec ces
 valeurs. Si le code appelant obtient une valeur `Err`, il peut appeler `panic!`
-et faire planter le programme, utiliser un nom d'utilisateur par défaut, ou
-chercher le nom d'utilisateur autre part que dans ce fichier, par exemple. Nous
-n'avons pas assez d'informations sur ce que le code appelant a l'intention de
-faire, donc nous remontons toutes les informations de succès ou d'erreur vers le
-haut pour qu'elles soient gérées correctement.
+et faire planter le programme, utiliser un pseudo par défaut, ou chercher le
+pseudo autre part que dans ce fichier, par exemple. Nous n'avons pas assez
+d'informations sur ce que le code appelant a l'intention de faire, donc nous
+remontons toutes les informations de succès ou d'erreur pour qu'elles soient
+gérées correctement.
 
 <!--
 This pattern of propagating errors is so common in Rust that Rust provides the
@@ -717,7 +717,7 @@ question mark operator `?` to make this easier.
 -->
 
 Cette façon de propager les erreurs est si courante en Rust que Rust fournit
-l'opérateur du point d'interrogation `?` pour faciliter ceci.
+l'opérateur point d'interrogation `?` pour faciliter ceci.
 
 <!--
 #### A Shortcut for Propagating Errors: the `?` Operator
@@ -731,9 +731,9 @@ same functionality as it had in Listing 9-6, but this implementation uses the
 `?` operator.
 -->
 
-L'encart 9-7 montre une implémentation de `read_username_from_file` qui a les
-mêmes fonctionnalités qu'elle a dans l'encart 9-6, mais cette implémentation
-utilise l'opérateur point d'interrogation :
+L'encart 9-7 montre une implémentation de `lire_pseudo_depuis_fichier` qui a les
+mêmes fonctionnalités que dans l'encart 9-6, mais cette implémentation utilise
+l'opérateur point d'interrogation :
 
 <!--
 <span class="filename">Filename: src/main.rs</span>
@@ -776,10 +776,10 @@ code.
 -->
 
 Le `?` placé après une valeur `Result` est conçu pour fonctionner presque de la
-même manière que les expressions `match` que nous avons défini pour gérer les
+même manière que les expressions `match` que nous avons définies pour gérer les
 valeurs `Result` dans l'encart 9-6. Si la valeur du `Result` est un `Ok`, la
 valeur dans le `Ok` sera retournée par cette expression et le programme
-continuera. Si la valeur est une `Err`, la `Err` sera retournée par la fonction
+continuera. Si la valeur est un `Err`, le `Err` sera retourné par la fonction
 comme si nous avions utilisé le mot-clé `return` afin que la valeur d'erreur
 soit propagée au code appelant.
 
@@ -798,17 +798,17 @@ conversion automatically.
 -->
 
 Il y a une différence entre ce que fait l'expression `match` de l'encart 9-6 et
-ce que fait l'opérateur `?` : les valeurs d'erreurs sur lesquelles sont
-utilisées l'opérateur `?` passent par la fonction `from`, définie dans le trait
-`From` de la bibliothèque standard, qui est utilisée pour convertir les erreurs
-d'un type à un autre. Lorsque l'opérateur `?` utilise la fonction `from`, le
-type d'erreur reçu est converti dans le type d'erreur déclaré dans le type de
-retour de la fonction concernée. C'est utile lorsque une fonction retourne un
-type d'erreur qui peut couvrir tous les cas d'échec de la fonction, même si
-certaines de ses parties peuvent échouer pour différentes raisons. A partir du
-moment que chaque type d'erreur implémente la fonction `from` pour expliquer
-comment se convertir elle-même dans le type d'erreur retourné, l'opérateur `?`
-se charge de faire la conversion automatiquement.
+ce que fait l'opérateur `?` : les valeurs d'erreurs sur lesquelles est utilisé
+l'opérateur `?` passent par la fonction `from`, définie dans le trait `From` de
+la bibliothèque standard, qui est utilisée pour convertir les erreurs d'un type
+à un autre. Lorsque l'opérateur `?` appelle la fonction `from`, le type d'erreur
+reçu est converti dans le type d'erreur déclaré dans le type de retour de la
+fonction concernée. C'est utile lorsqu'une fonction retourne un type d'erreur
+qui peut couvrir tous les cas d'échec de la fonction, même si certaines de ses
+parties peuvent échouer pour différentes raisons. À partir du moment que chaque
+type d'erreur implémente la fonction `from` pour expliquer comment se convertir
+lui-même dans le type d'erreur retourné, l'opérateur `?` se charge de faire la
+conversion automatiquement.
 
 <!--
 In the context of Listing 9-7, the `?` at the end of the `File::open` call will
@@ -820,8 +820,8 @@ value to the calling code. The same thing applies to the `?` at the end of the
 
 Dans le cas de l'encart 9-7, le `?` à la fin de l'appel à `File::open` va
 retourner la valeur à l'intérieur d'un `Ok` à la variable `f`. Si une erreur se
-produit, l'opérateur `?` va retourner prématurément la fonction et fournir une
-valeur `Err` au code appelant. La même chose se produira au `?` à ma fin de
+produit, l'opérateur `?` va quitter prématurément la fonction et retourner une
+valeur `Err` au code appelant. La même chose se produira au `?` à la fin de
 l'appel à `read_to_string`.
 
 <!--
@@ -830,7 +830,7 @@ implementation simpler. We could even shorten this code further by chaining
 method calls immediately after the `?`, as shown in Listing 9-8.
 -->
 
-L'opérateur `?` épargne de l'écriture de code et facilite l'implémentation de la
+L'opérateur `?` allège l'écriture de code et facilite l'implémentation de la
 fonction. Nous pouvons même encore plus réduire ce code en enchaînant
 immédiatement les appels aux méthodes après le `?` comme dans l'encart 9-8 :
 
@@ -876,14 +876,14 @@ Listing 9-7; this is just a different, more ergonomic way to write it.
 -->
 
 Nous avons déplacé la création de la nouvelle `String` dans `s` au début de la
-fonction ; cette partie n'a pas changée. Au lieu de créer la variable `f`, nous
+fonction ; cette partie n'a pas changé. Au lieu de créer la variable `f`, nous
 enchaînons directement l'appel à `read_to_string` sur le résultat de
 `File::open("hello.txt")?`. Nous avons toujours le `?` à la fin de l'appel à
-`read_to_string`, et nous retournons toujours une valeur `Ok` contenant le nom
-d'utilisateur dans `s` lorsque `File::open` et `read_to_string` réussissent
-toutes les deux plutôt que de retourner des erreurs. Cette fonctionnalité est
-toujours la même que dans l'encart 9-6 et l'encart 9-7 ; c'est juste une façon
-différente et plus ergonomique de l'écrire.
+`read_to_string`, et nous retournons toujours une valeur `Ok` contenant le
+pseudo dans `s` lorsque `File::open` et `read_to_string` réussissent toutes les
+deux plutôt que de retourner des erreurs. Cette fonctionnalité est toujours la
+même que dans l'encart 9-6 et l'encart 9-7 ; c'est juste une façon différente et
+plus ergonomique de l'écrire.
 
 <!--
 Speaking of different ways to write this function, Listing 9-9 shows that
@@ -920,8 +920,8 @@ don't want to include it for rustdoc testing purposes. -- >
 opening and then reading the file</span>
 -->
 
-<span class="caption">Encart 9-9: utilisation de `fs::read_to_string` plutôt que
-d'ouvrir puis lire le fichier</span>
+<span class="caption">Encart 9-9 : utilisation de `fs::read_to_string` plutôt
+que d'ouvrir puis lire le fichier</span>
 
 <!--
 Reading a file into a string is a fairly common operation, so Rust provides the
@@ -933,11 +933,11 @@ first.
 -->
 
 Récupérer le contenu d'un fichier dans une `String` est une opération assez
-courante, donc Rust fournir la fonction `fs::read_to_string` assez pratique, qui
-ouvre le fichier, crée une nouvelle `String`, lit de contenu du fichier, envoie
-le contenu dans cette `String`, et la retourne. Evidemment, l'utilisation de
+courante, donc Rust fournit la fonction `fs::read_to_string` assez pratique, qui
+ouvre le fichier, crée une nouvelle `String`, lit le contenu du fichier, insère
+ce contenu dans cette `String`, et la retourne. Évidemment, l'utilisation de
 `fs:read_to_string` ne nous offre pas l'occasion d'expliquer toute la gestion
-des erreurs, donc nous utiliserons d'abord la façon qui est plus longue.
+des erreurs, donc nous avons d'abord utilisé la façon qui est plus longue.
 
 <!--
 #### The `?` Operator Can Be Used in Functions That Return `Result`
@@ -955,7 +955,7 @@ has to be a `Result` to be compatible with this `return`.
 
 L'opérateur `?` peut être utilisé dans des fonctions qui ont un type de retour
 `Result`, car il est conçu pour fonctionner de la même manière que l'expression
-`match` que nous avons utilisé dans l'encart 9-6. La partie du `match` qui
+`match` que nous avons utilisée dans l'encart 9-6. La partie du `match` qui
 nécessite le type de retour `Result` est `return Err(e)`, donc le type de retour
 de cette fonction doit être un `Result` pour être compatible avec ce `return`.
 
@@ -964,9 +964,8 @@ Let’s look at what happens if we use the `?` operator in the `main` function,
 which you’ll recall has a return type of `()`:
 -->
 
-Voyons ce que ce passe si nous utilisons l'opérateur `?` dans la fonction
-`main`, pour laquelle vous devriez vous souvenir qu'elle a un type de retour
-`()` :
+Voyons ce qui se passe si nous utilisons l'opérateur `?` dans la fonction `main`
+qui, souvenez-vous, a comme type de retour `()` :
 
 <!--
 ```rust,ignore,does_not_compile
@@ -1006,14 +1005,14 @@ a `match` or one of the `Result<T, E>` methods to handle the `Result<T, E>` in
 whatever way is appropriate.
 -->
 
-Cette erreur explique que nous sommes uniquement autorisés à utiliser
-l'opérateur `?` dans une fonction qui retourne `Result` ou `Option` ou un autre
-type qui implémente `std::ops::Try`. Lorsque vous écrivez du code dans une
-fonction qui ne retourne pas un de ces types, et que vous souhaitez utiliser `?`
-lorsque vous appelez d'autres fonctions qui retournent `Result<T, E>`, vous avez
-deux façons de régler le problème. La première est de changer le type de retour
-de votre fonction en `Result<T, E>` si vous pouvez le faire. L'autre solution
-est d'utiliser un `match` ou une des méthodes de `Result<T, E>` pour gérer le
+Cette erreur explique que nous sommes autorisés à utiliser l'opérateur `?`
+uniquement dans une fonction qui retourne `Result`, `Option` ou un autre type
+qui implémente `std::ops::Try`. Lorsque vous écrivez du code dans une fonction
+qui ne retourne pas un de ces types et que vous souhaitez utiliser `?` lorsque
+vous appelez d'autres fonctions qui retournent `Result<T, E>`, vous avez deux
+façons de régler le problème. La première est de changer le type de retour de
+votre fonction en `Result<T, E>` si vous pouvez le faire. L'autre solution est
+d'utiliser un `match` ou une des méthodes de `Result<T, E>` pour gérer le
 `Result<T, E>` de la manière la plus appropriée.
 
 <!--
@@ -1023,8 +1022,8 @@ valid return type is `Result<T, E>`, as shown here:
 -->
 
 La fonction `main` est spéciale, et il y a des restrictions sur ce que doit être
-son type de retour. Une type de retour correct pour `main` est `()`, et il
-existe aussi un autre type de retour acceptable qui est `Result<T, E>`, comme
+son type de retour. Un type de retour correct pour `main` est `()`, et il existe
+aussi un autre type de retour acceptable qui est `Result<T, E>`, comme
 ci-dessous :
 
 <!--
@@ -1045,11 +1044,10 @@ read `Box<dyn Error>` to mean “any kind of error.” Using `?` in a `main`
 function with this return type is allowed.
 -->
 
-Le type `Box<dyn Error>` est ce qu'on appelle un objet trait, que nous allons
-voir dans une section du [chapitre 17][trait-objects]<!-- ignore -->. Pour
-l'instant vous pouvez interpréter `Box<dyn Error>` en “tout type d'erreur”.
-L'utilisation de `?` dans la fonction `main` avec ce type de retour est donc
-autorisée.
+Le type `Box<dyn Error>` est ce qu'on appelle un objet trait, que nous verrons
+dans une section du [chapitre 17][trait-objects]<!-- ignore -->. Pour l'instant,
+vous pouvez interpréter `Box<dyn Error>` en “tout type d'erreur”. L'utilisation
+de `?` dans la fonction `main` avec ce type de retour est donc autorisée.
 
 <!--
 Now that we’ve discussed the details of calling `panic!` or returning `Result`,


### PR DESCRIPTION
J'ai raccourci certains messages d'erreur pour que la largeur soit inférieure à 80 colonnes et donc qu'il ne soit pas nécessaire de scroller les bouts de code latéralement pour les lire.
J'ai aussi remplacé "nom d'utilisateur" par "pseudo" pour des raisons similaires de concision.