### PR TITLE
Fix minor typo

### DIFF
--- a/FRENCH/src/ch04-01-what-is-ownership.md
+++ b/FRENCH/src/ch04-01-what-is-ownership.md
@@ -337,7 +337,7 @@ donnée qui est plus complexe que ceux que nous avons rencontrés dans la sectio
 nous avons vus précédemment ont tous une taille connue et peuvent être stockés
 sur la pile ainsi que retirés de la pile lorsque la portée n'en a plus besoin,
 et peuvent aussi être rapidement et facilement afin de constituer une nouvelle
-instance indépendante si une utrre partie du code a besoin d'utiliser la même
+instance indépendante si une autre partie du code a besoin d'utiliser la même
 valeur dans une portée différente. Mais nous voulons expérimenter le stockage
 de données sur le tas et découvrir comment Rust sait quand il doit nettoyer ces
 données, et le type `String` est un bon exemple.


### PR DESCRIPTION
Hello, 

Petite faute de frappe : `utrre` à la place de `autre`.

Merci pour la trad :heart: 

