### PR TITLE
Fix content of article in ch10-02

### DIFF
--- a/FRENCH/listings/ch10-generic-types-traits-and-lifetimes/no-listing-02-calling-default-impl/src/main.rs
+++ b/FRENCH/listings/ch10-generic-types-traits-and-lifetimes/no-listing-02-calling-default-impl/src/main.rs
@@ -3,15 +3,15 @@ use chapter10::{self, ArticleDePresse, Resumable};
 fn main() {
     // ANCHOR: here
     let article = ArticleDePresse {
-        titre: String::from("Les Pinguins ont gagné la Stanley Cup Championship !"),
+        titre: String::from("Les Penguins ont remporté la Coupe Stanley !"),
         lieu: String::from("Pittsburgh, PA, USA"),
         auteur: String::from("Iceburgh"),
         contenu: String::from(
-            "Les Pinguins de Pittsburgh sont une nouvelle fois la meilleure\
-            équipe de hockey de la NHL."
+            "Les Penguins de Pittsburgh sont une nouvelle fois la meilleure \
+            équipe de hockey de la LNH.",
         ),
     };
-    
+
     println!("Nouvel article disponible ! {}", article.resumer());
     // ANCHOR_END: here
 }

--- a/FRENCH/listings/ch10-generic-types-traits-and-lifetimes/no-listing-06-impl-trait-returns-one-type/src/lib.rs
+++ b/FRENCH/listings/ch10-generic-types-traits-and-lifetimes/no-listing-06-impl-trait-returns-one-type/src/lib.rs
@@ -32,11 +32,11 @@ impl Resumable for Tweet {
 fn retourne_resumable(estArticle: bool) -> impl Resumable {
     if estArticle {
         ArticleDePresse {
-            titre: String::from("Les Pinguins ont gagné la Stanley Cup Championship !"),
+            titre: String::from("Les Penguins ont remporté la Coupe Stanley !"),
             lieu: String::from("Pittsburgh, PA, USA"),
             auteur: String::from("Iceburgh"),
-            contenu: String::from("Les Pinguins de Pittsburgh sont une nouvelle fois la
-            meilleure équipe de hockey de la NHL."),
+            contenu: String::from("Les Penguins de Pittsburgh sont une nouvelle fois la meilleure \
+            équipe de hockey de la LNH."),
         }
     } else {
         Tweet {

--- a/FRENCH/listings/ch10-generic-types-traits-and-lifetimes/no-listing-06-impl-trait-returns-one-type/src/lib.rs
+++ b/FRENCH/listings/ch10-generic-types-traits-and-lifetimes/no-listing-06-impl-trait-returns-one-type/src/lib.rs
@@ -35,8 +35,8 @@ fn retourne_resumable(estArticle: bool) -> impl Resumable {
             titre: String::from("Les Penguins ont remporté la Coupe Stanley !"),
             lieu: String::from("Pittsburgh, PA, USA"),
             auteur: String::from("Iceburgh"),
-            contenu: String::from("Les Penguins de Pittsburgh sont une nouvelle fois la meilleure \
-            équipe de hockey de la LNH."),
+            contenu: String::from("Les Penguins de Pittsburgh sont une nouvelle fois la \
+            meilleure équipe de hockey de la LNH."),
         }
     } else {
         Tweet {


### PR DESCRIPTION
Correction du contenu de l'article du presse du chapitre 10-02 au niveau de la traduction (en vérifiant les termes sur le site de la LNH) et au niveau du retour à la ligne dans le littéral de chaîne du champ `contenu`.