### PR TITLE
Fix a possible misinterpretation

### DIFF
--- a/FRENCH/listings/ch04-understanding-ownership/listing-04-03/src/main.rs
+++ b/FRENCH/listings/ch04-understanding-ownership/listing-04-03/src/main.rs
@@ -8,7 +8,7 @@ fn main() {
 
   creer_copie(x);         // x va être déplacée dans la fonction,
                           // mais i32 est Copy, donc on peut
-                          // utiliser x ensuite.
+                          // continuer d'utiliser x ensuite.
 
 } // Ici, x sort de la portée, puis ensuite s. Mais puisque la valeur de s a
 // été déplacée, il ne se passe rien de spécial.

--- a/FRENCH/src/ch04-01-what-is-ownership.md
+++ b/FRENCH/src/ch04-01-what-is-ownership.md
@@ -1003,9 +1003,10 @@ implement `Copy`:
 
 Donc, quels sont les types qui implémentent le trait `Copy` ? Vous pouvez
 regarder dans la documentation pour un type donné pour vous en assurer, mais de
-manière générale, tout groupe de valeur scalaire peut implémenter `Copy`, et
-tout ce qui ne nécessite pas d'allocation de mémoire ou tout autre forme de
-ressource qui implémente `Copy`. Voici quelques types qui implémentent `Copy` :
+manière générale, tout groupe de valeurs scalaires peut implémenter `Copy`, et
+rien de ce qui nécessite une allocation de mémoire ou qui est une forme de
+ressource ne peut implémenter `Copy`. Voici quelques types qui implémentent
+Copy` :
 
 <!--
 * All the integer types, such as `u32`.

--- a/FRENCH/src/ch04-01-what-is-ownership.md
+++ b/FRENCH/src/ch04-01-what-is-ownership.md
@@ -1145,7 +1145,7 @@ from the body of the function that we might want to return as well.
 Même si cela fonctionne, il est un peu fastidieux de prendre la possession puis
 ensuite de retourner la possession à chaque fonction. Et qu'est-ce qu'il se
 passe si nous voulons qu'une fonction utilise une valeur, mais n'en prenne pas
-possession ? C'est assez pénible que tout ce que nous passons doit être
+possession ? C'est assez pénible que tout ce que nous passons doive être
 retourné si nous voulons l'utiliser à nouveau, en plus de toutes les données
 qui découlent du corps de la fonction que nous voulons aussi récupérer.
 

--- a/FRENCH/src/ch04-01-what-is-ownership.md
+++ b/FRENCH/src/ch04-01-what-is-ownership.md
@@ -1020,7 +1020,7 @@ Copy` :
 * Tous les types d'entiers, comme `u32`.
 * Le type booléen, `bool`, avec les valeurs `true` et `false`.
 * Tous les types de flottants, comme `f64`.
-* Le type de caractère, `char`.
+* Le type caractère, `char`.
 * Les tuples, mais uniquement s'ils contiennent des types qui implémentent
   aussi `Copy`. Par exemple, le `(i32, i32)` implémente `Copy`, mais pas
   `(i32, String)`.
@@ -1038,7 +1038,7 @@ copy, just as assignment does. Listing 4-3 has an example with some annotations
 showing where variables go into and out of scope.
 -->
 
-La syntaxe pour passer une valeur à une fonction est similaire à celle pour
+La mécanique pour passer une valeur à une fonction est similaire à celle pour
 assigner une valeur à une variable. Passer une variable à une fonction va la
 déplacer ou la copier, comme l'assignation. L'encart 4-3 est un exemple avec
 quelques commentaires qui montrent où les variables rentrent et sortent de la


### PR DESCRIPTION
Plusieurs suggestions de corrections.

"groupe de valeur scalaire" -> "groupe de valeurs scalaires"

Une partie du texte concernant le trait Copy a été traduite en transformant une tournure négative en une tournure positive avec quelques adaptations.
Je pense que l'intention était de rendre la phrase plus claire, car le texte source n'est pas complètement limpide il faut l'avouer. Mais j'ai peur que le résultat soit carrément un contreses, et je pense qu'il est préférable de conserver la tournure négative pour coller au plus près du sens d'origine.

"le type de caractère" -> "le type caractère"

"La syntaxe pour passer une valeur à une fonction" -> "La mécanique pour passer une valeur à une fonction"
(le mot "syntaxe" est incorrect pour traduire "semantics" dans ce contexte, et j'anticipe un peu sur la version actuelle en anglais qui a remplacé "semantics" par "mechanics")


