### PR TITLE
Update ch04-02-references-and-borrowing.md

### DIFF
--- a/FRENCH/src/ch04-02-references-and-borrowing.md
+++ b/FRENCH/src/ch04-02-references-and-borrowing.md
@@ -259,9 +259,9 @@ clear that the `change` function will mutate the value it borrows.
 -->
 
 D'abord, nous précisons que `s` est `mut`. Ensuite, nous avons créé une
-référence mutable avec `&mut s` où nous appelons la fonction `change` et nous
+référence mutable avec `&mut s` où nous appelons la fonction `changer` et nous
 avons modifié la signature pour accepter de prendre une référence mutable avec
-`texte: &mut String`. Cela précise clairement que la fonction `change` va faire
+`texte: &mut String`. Cela précise clairement que la fonction `changer` va faire
 muter la valeur qu'elle emprunte.
 
 <!--


### PR DESCRIPTION
The function name "change" is translated "changer" (with 'r') in the code example. So, the explanation should be translated "changer" too =)

![image](https://github.com/Jimskapt/rust-book-fr/assets/18363709/e3f93b25-55d6-4bad-9e38-c90adc3507e9)
