### PR TITLE
A proposition of translation for "empowerment" in Foreword

### DIFF
--- a/FRENCH/src/ch03-02-data-types.md
+++ b/FRENCH/src/ch03-02-data-types.md
@@ -293,7 +293,7 @@ d'entier par défaut est le `i32`. La principale utilisation d'un `isize` ou d'u
 > Rust va effectuer un *rebouclage du complément à deux*. Pour faire simple, les
 > valeurs supérieures à la valeur maximale du type seront “rebouclées” depuis la
 > valeur minimale que le type peut stocker. Dans le cas d'un `u8`, la valeur 256
-> devient 0, la valeur 257 devient 1, et ainsi de suite. Le programme ne va
+> devient 0, la valeur 257 devient 1, et ainsi de suite. Le programme ne va pas
 > paniquer, mais la variable va avoir une valeur qui n'est probablement pas ce
 > que vous attendez à avoir. Se fier au comportement du rebouclage lors du
 > dépassement d'entier est considéré comme une faute.

--- a/FRENCH/src/foreword.md
+++ b/FRENCH/src/foreword.md
@@ -12,8 +12,8 @@ domains than you did before.
 -->
 
 Cela n'a pas toujours été aussi évident, mais le langage de programmation Rust
-apporte avant tout plus de *puissance* : peu importe le type de code que vous
-écrivez en ce moment, Rust vous permet d'aller plus loin et de
+vous donne fondamentallement *plus de pouvoirs* : peu importe le type de code que vous
+écrivez en ce moment, Rust vous donne le pouvoir d'aller plus loin et de
 programmer en toute confiance dans une plus grande diversité de domaines
 qu'auparavant.
 

--- a/FRENCH/src/foreword.md
+++ b/FRENCH/src/foreword.md
@@ -12,7 +12,7 @@ domains than you did before.
 -->
 
 Cela n'a pas toujours été aussi évident, mais le langage de programmation Rust
-vous donne fondamentallement *plus de pouvoirs* : peu importe le type de code que vous
+vous donne avant tout *plus de pouvoirs* : peu importe le type de code que vous
 écrivez en ce moment, Rust vous donne le pouvoir d'aller plus loin et de
 programmer en toute confiance dans une plus grande diversité de domaines
 qu'auparavant.
@@ -94,8 +94,8 @@ knowledge of Rust, but also your reach and confidence as a programmer in
 general. So dive in, get ready to learn—and welcome to the Rust community!
 -->
 
-Ce livre exploite pleinement le potentiel de Rust pour permettre à ses
-utilisateurs de se perfectionner. C'est une documentation conviviale et accessible
+Ce livre exploite pleinement le potentiel de Rust pour donner à ses
+utilisateurs plus de pouvoirs. C'est une documentation conviviale et accessible
 destinée à améliorer vos connaissances en Rust, mais aussi à améliorer vos
 capacités et votre assurance en tant que développeur en général. Alors foncez,
 préparez-vous à apprendre, et bienvenue dans la communauté Rust !


### PR DESCRIPTION
In the English version of the foreword, the word "empower" is used in the beginning and at the end which creates a nice loop and makes a point clear: it is more about what the programmer can do than anything else.
In the french translation, this is less clear because "empower" is translation as "permettre plus de puissance" at the beginning and "permettre de se perfectionner" at the end.
(There is the new french word "encapaciter" but) I propose to use the expression "donner plus de pouvoir" in both places.
The reason is that "power" means "puissance" or "pouvoir" in french depending on the context.
Here, I think "pouvoir" is the right french concept, as in "I can do that / I have the power to do that" which translates into "Je peux faire ça / J'ai le pouvoir de faire ça" according to me.
So this was my reasoning, but I might be wrong,
It is up to you to valide this reasoning or not.

PS: I'm about to use this document with my (french) students, this is why I care.